### PR TITLE
feat: add picross puzzle game

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,94 +1,46 @@
-import React, { useEffect, useState } from "react";
-import GameMenu, { GameId } from "./components/GameMenu";
-import PingPongCanvas from "./PingPongCanvas";
-import TetrisCanvas from "./TetrisCanvas";
-import SnakeCanvas from "./SnakeCanvas";
-import OmokCanvas from "./OmokCanvas";
-import LightsOutCanvas from "./LightsOutCanvas";
-import SimonSaysCanvas from "./SimonSaysCanvas";
-import ReactionTestCanvas from "./ReactionTestCanvas";
-import AimTrainerCanvas from "./AimTrainerCanvas";
-import BreakoutCanvas from "./BreakoutCanvas";
-import FlappyBirdCanvas from "./FlappyBirdCanvas";
-import MemoryGameCanvas from "./MemoryGameCanvas";
-import DodgeGameCanvas from "./DodgeGameCanvas";
-import Game2048Canvas from "./Game2048Canvas";
-import SlidePuzzleCanvas from "./SlidePuzzleCanvas";
-import SokobanCanvas from "./SokobanCanvas";
-import ConnectFourCanvas from "./ConnectFourCanvas";
-import MiniGolfCanvas from "./MiniGolfCanvas";
-import TicTacToeCanvas from "./TicTacToeCanvas";
+import React, { useEffect, useState } from 'react';
+import GameMenu from './components/GameMenu';
+import { games, GameId } from './games';
+
+type GameView = GameId | 'menu';
 
 export default function App() {
-  const [game, setGame] = useState<GameId>("menu");
+  const [game, setGame] = useState<GameView>('menu');
 
   useEffect(() => {
+    const hotkeyMap: Record<string, GameId> = {};
+    games.forEach((g) => {
+      hotkeyMap[g.hotkey.toLowerCase()] = g.id;
+    });
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "1") setGame("pingpong");
-      if (e.key === "2") setGame("tetris");
-      if (e.key === "3") setGame("snake");
-      if (e.key === "4") setGame("omok");
-      if (e.key === "5") setGame("lightsout");
-      if (e.key === "6") setGame("simon");
-      if (e.key === "7") setGame("reaction");
-      if (e.key === "8") setGame("aim");
-      if (e.key === "9") setGame("breakout");
-      if (e.key === "0") setGame("flappy");
-      if (e.key === "m") setGame("memory");
-      if (e.key === "d") setGame("dodge");
-      if (e.key === "-") setGame("2048");
-      if (e.key === "=") setGame("slide");
-      if (e.key === "s") setGame("sokoban");
-      if (e.key === "c") setGame("connect4");
-      if (e.key === "g") setGame("minigolf");
-      if (e.key === "t") setGame("tictactoe");
-      if (e.key === "Escape") setGame("menu");
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.repeat) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const key = e.key.toLowerCase();
+      if (key === 'escape') {
+        setGame('menu');
+        return;
+      }
+      const id = hotkeyMap[key];
+      if (id) setGame(id);
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  if (game === "menu") return <GameMenu onSelect={(id) => setGame(id)} />;
-
-  switch (game) {
-    case "pingpong":
-      return <PingPongCanvas width={900} height={540} />;
-    case "tetris":
-      return <TetrisCanvas />;
-    case "snake":
-      return <SnakeCanvas />;
-    case "omok":
-      return <OmokCanvas />;
-    case "lightsout":
-      return <LightsOutCanvas />;
-    case "simon":
-      return <SimonSaysCanvas />;
-    case "reaction":
-      return <ReactionTestCanvas />;
-    case "aim":
-      return <AimTrainerCanvas />;
-    case "breakout":
-      return <BreakoutCanvas />;
-    case "flappy":
-      return <FlappyBirdCanvas />;
-    case "memory":
-      return <MemoryGameCanvas />;
-    case "dodge":
-      return <DodgeGameCanvas />;
-    case "2048":
-      return <Game2048Canvas />;
-    case "slide":
-      return <SlidePuzzleCanvas />;
-    case "sokoban":
-      return <SokobanCanvas />;
-    case "connect4":
-      return <ConnectFourCanvas />;
-    case "minigolf":
-      return <MiniGolfCanvas />;
-    case "tictactoe":
-      return <TicTacToeCanvas />;
-    default:
-      return null;
+  if (game === 'menu') {
+    return <GameMenu games={games} onSelect={(id) => setGame(id)} />;
   }
-}
 
+  const current = games.find((g) => g.id === game);
+  return current ? current.render() : null;
+}

--- a/src/ConnectFourCanvas.tsx
+++ b/src/ConnectFourCanvas.tsx
@@ -29,7 +29,8 @@ const CANVAS_WIDTH = 700;
 const CANVAS_HEIGHT = 600;
 const CELL_SIZE = 80;
 const CHIP_RADIUS = 30;
-const MARGIN = 50;
+const MARGIN_X = (CANVAS_WIDTH - COLS * CELL_SIZE) / 2;
+const MARGIN_Y = (CANVAS_HEIGHT - ROWS * CELL_SIZE) / 2;
 
 // 칩 색상
 const CHIP_COLORS = {
@@ -279,7 +280,7 @@ const ConnectFourCanvas: React.FC = () => {
 
     const rect = canvas.getBoundingClientRect();
     const x = event.clientX - rect.left;
-    const col = Math.floor((x - MARGIN) / CELL_SIZE);
+    const col = Math.floor((x - MARGIN_X) / CELL_SIZE);
 
     if (col >= 0 && col < COLS) {
       makeMove(col);
@@ -298,7 +299,7 @@ const ConnectFourCanvas: React.FC = () => {
 
     const rect = canvas.getBoundingClientRect();
     const x = event.clientX - rect.left;
-    const col = Math.floor((x - MARGIN) / CELL_SIZE);
+    const col = Math.floor((x - MARGIN_X) / CELL_SIZE);
 
     if (col >= 0 && col < COLS && isValidMove(board, col)) {
       setHoveredCol(col);
@@ -322,8 +323,8 @@ const ConnectFourCanvas: React.FC = () => {
     // 그리드 그리기
     for (let row = 0; row < ROWS; row++) {
       for (let col = 0; col < COLS; col++) {
-        const x = MARGIN + col * CELL_SIZE;
-        const y = MARGIN + row * CELL_SIZE;
+        const x = MARGIN_X + col * CELL_SIZE;
+        const y = MARGIN_Y + row * CELL_SIZE;
         const centerX = x + CELL_SIZE / 2;
         const centerY = y + CELL_SIZE / 2;
 
@@ -368,17 +369,17 @@ const ConnectFourCanvas: React.FC = () => {
 
     // 호버된 열 하이라이트
     if (hoveredCol !== null && gameState === GameState.PLAYING) {
-      const x = MARGIN + hoveredCol * CELL_SIZE;
+      const x = MARGIN_X + hoveredCol * CELL_SIZE;
       ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
-      ctx.fillRect(x, MARGIN, CELL_SIZE, ROWS * CELL_SIZE);
+      ctx.fillRect(x, MARGIN_Y, CELL_SIZE, ROWS * CELL_SIZE);
     }
 
     // 드랍 애니메이션
     if (droppingChip) {
       const { col, row, progress } = droppingChip;
-      const x = MARGIN + col * CELL_SIZE + CELL_SIZE / 2;
-      const startY = MARGIN - CHIP_RADIUS;
-      const endY = MARGIN + row * CELL_SIZE + CELL_SIZE / 2;
+      const x = MARGIN_X + col * CELL_SIZE + CELL_SIZE / 2;
+      const startY = MARGIN_Y - CHIP_RADIUS;
+      const endY = MARGIN_Y + row * CELL_SIZE + CELL_SIZE / 2;
       const currentY = startY + (endY - startY) * progress;
 
       ctx.fillStyle = CHIP_COLORS[currentPlayer];

--- a/src/FroggerCanvas.tsx
+++ b/src/FroggerCanvas.tsx
@@ -1,0 +1,192 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const FROG_SIZE = 40;
+const SAFE_ZONE = 60;
+const LANE_HEIGHT = 60;
+const LANE_GAP = 20;
+const LANES = 3;
+
+interface Car {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  speed: number;
+}
+
+const FroggerCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const carsRef = useRef<Car[]>([]);
+  const frogRef = useRef({ x: 0, y: 0 });
+
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [gameState, setGameState] = useState<'playing' | 'gameover'>('playing');
+
+  const initCars = useCallback(() => {
+    const cars: Car[] = [];
+    const speeds = [120, -150, 100];
+    for (let i = 0; i < LANES; i++) {
+      const y = CANVAS_HEIGHT - SAFE_ZONE - (i + 1) * (LANE_HEIGHT + LANE_GAP) + (LANE_HEIGHT - 40) / 2;
+      for (let j = 0; j < 3; j++) {
+        cars.push({
+          x: j * (CANVAS_WIDTH / 3),
+          y,
+          width: 80,
+          height: 40,
+          speed: speeds[i]
+        });
+      }
+    }
+    carsRef.current = cars;
+  }, []);
+
+  const resetFrog = useCallback(() => {
+    frogRef.current = {
+      x: CANVAS_WIDTH / 2 - FROG_SIZE / 2,
+      y: CANVAS_HEIGHT - SAFE_ZONE + (SAFE_ZONE - FROG_SIZE) / 2
+    };
+  }, []);
+
+  const startGame = useCallback(() => {
+    setScore(0);
+    setLives(3);
+    setGameState('playing');
+    initCars();
+    resetFrog();
+  }, [initCars, resetFrog]);
+
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    if (gameState !== 'playing') return;
+    const frog = frogRef.current;
+    switch (e.key) {
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        frog.y = Math.max(0, frog.y - FROG_SIZE);
+        break;
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        frog.y = Math.min(CANVAS_HEIGHT - FROG_SIZE, frog.y + FROG_SIZE);
+        break;
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        frog.x = Math.max(0, frog.x - FROG_SIZE);
+        break;
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        frog.x = Math.min(CANVAS_WIDTH - FROG_SIZE, frog.x + FROG_SIZE);
+        break;
+    }
+    if (frog.y <= 0) {
+      setScore(s => s + 1);
+      resetFrog();
+    }
+  }, [gameState, resetFrog]);
+
+  const update = useCallback((dt: number) => {
+    if (gameState !== 'playing') return;
+    const frog = frogRef.current;
+    carsRef.current.forEach(car => {
+      car.x += car.speed * dt;
+      if (car.speed > 0 && car.x > CANVAS_WIDTH + car.width) car.x = -car.width;
+      if (car.speed < 0 && car.x < -car.width) car.x = CANVAS_WIDTH + car.width;
+      if (
+        frog.x < car.x + car.width &&
+        frog.x + FROG_SIZE > car.x &&
+        frog.y < car.y + car.height &&
+        frog.y + FROG_SIZE > car.y
+      ) {
+        setLives(l => {
+          const nl = l - 1;
+          if (nl <= 0) setGameState('gameover');
+          return nl;
+        });
+        resetFrog();
+      }
+    });
+  }, [gameState, resetFrog]);
+
+  const draw = useCallback(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // background
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // safe zones
+    ctx.fillStyle = '#3b5';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, SAFE_ZONE);
+    ctx.fillRect(0, CANVAS_HEIGHT - SAFE_ZONE, CANVAS_WIDTH, SAFE_ZONE);
+
+    // lanes
+    ctx.fillStyle = '#555';
+    for (let i = 0; i < LANES; i++) {
+      const y = CANVAS_HEIGHT - SAFE_ZONE - (i + 1) * (LANE_HEIGHT + LANE_GAP);
+      ctx.fillRect(0, y, CANVAS_WIDTH, LANE_HEIGHT);
+    }
+
+    // cars
+    ctx.fillStyle = 'orange';
+    carsRef.current.forEach(car => {
+      ctx.fillRect(car.x, car.y, car.width, car.height);
+    });
+
+    // frog
+    ctx.fillStyle = 'lime';
+    const frog = frogRef.current;
+    ctx.fillRect(frog.x, frog.y, FROG_SIZE, FROG_SIZE);
+  }, []);
+
+  const loop = useCallback((time: number) => {
+    const prev = (loop as any).prev || time;
+    const dt = (time - prev) / 1000;
+    (loop as any).prev = time;
+    update(dt);
+    draw();
+    animationRef.current = requestAnimationFrame(loop);
+  }, [draw, update]);
+
+  useEffect(() => {
+    startGame();
+    const handler = (e: KeyboardEvent) => handleKey(e);
+    window.addEventListener('keydown', handler);
+    animationRef.current = requestAnimationFrame(loop);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [handleKey, loop, startGame]);
+
+  return (
+    <GameManager
+      title="Frogger"
+      gameIcon="🐸"
+      gameStats={<div>Score: {score} | Lives: {lives}</div>}
+      gameStatus={gameState === 'gameover' ? 'Game Over' : undefined}
+      actionButtons={<GameButton onClick={startGame}>Reset</GameButton>}
+      instructions={<div>방향키로 이동하여 위쪽으로 건너가세요</div>}
+    >
+      <GameCanvas
+        gameTitle="frogger"
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+      />
+    </GameManager>
+  );
+};
+
+export default FroggerCanvas;

--- a/src/MastermindCanvas.tsx
+++ b/src/MastermindCanvas.tsx
@@ -1,0 +1,277 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const ROWS = 10;
+const PEGS = 4;
+const COLORS = ['#e74c3c', '#3498db', '#27ae60', '#f1c40f', '#e91e63', '#8e44ad'];
+const COLOR_NAMES = ['빨강', '파랑', '초록', '노랑', '분홍', '보라'];
+const CANVAS_WIDTH = 360;
+const CANVAS_HEIGHT = 640;
+const TOP_MARGIN = 40;
+const ROW_SPACING = 40;
+const PEG_RADIUS = 12;
+const PEG_SPACING = 40;
+const FEEDBACK_RADIUS = 6;
+const FEEDBACK_SPACING = 16;
+const PALETTE_RADIUS = 15;
+const PALETTE_SPACING = 40;
+
+function generateSecret() {
+  return Array.from({ length: PEGS }, () => Math.floor(Math.random() * COLORS.length));
+}
+
+const MastermindCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [secret, setSecret] = useState<number[]>(() => generateSecret());
+  const [guesses, setGuesses] = useState<number[][]>(
+    Array.from({ length: ROWS }, () => Array(PEGS).fill(-1))
+  );
+  const [results, setResults] = useState<{ correct: number; misplaced: number }[]>([]);
+  const [currentRow, setCurrentRow] = useState(0);
+  const [gameState, setGameState] = useState<'playing' | 'won' | 'lost'>('playing');
+
+  const resetGame = useCallback(() => {
+    setSecret(generateSecret());
+    setGuesses(Array.from({ length: ROWS }, () => Array(PEGS).fill(-1)));
+    setResults([]);
+    setCurrentRow(0);
+    setGameState('playing');
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (gameState !== 'playing') return;
+    const row = guesses[currentRow];
+    let idx = -1;
+    for (let i = PEGS - 1; i >= 0; i--) {
+      if (row[i] !== -1) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) return;
+    const newGuesses = guesses.map((r, ri) =>
+      ri === currentRow ? r.map((v, ci) => (ci === idx ? -1 : v)) : r
+    );
+    setGuesses(newGuesses);
+  }, [gameState, guesses, currentRow]);
+
+  const submitGuess = useCallback(() => {
+    if (gameState !== 'playing') return;
+    if (guesses[currentRow].some(v => v === -1)) return;
+    const guess = guesses[currentRow];
+
+    const secretUsed = Array(PEGS).fill(false);
+    const guessUsed = Array(PEGS).fill(false);
+    let correct = 0;
+    let misplaced = 0;
+
+    for (let i = 0; i < PEGS; i++) {
+      if (guess[i] === secret[i]) {
+        correct++;
+        secretUsed[i] = true;
+        guessUsed[i] = true;
+      }
+    }
+    for (let i = 0; i < PEGS; i++) {
+      if (guessUsed[i]) continue;
+      for (let j = 0; j < PEGS; j++) {
+        if (!secretUsed[j] && guess[i] === secret[j]) {
+          misplaced++;
+          secretUsed[j] = true;
+          break;
+        }
+      }
+    }
+
+    const newResults = [...results];
+    newResults[currentRow] = { correct, misplaced };
+    setResults(newResults);
+
+    if (correct === PEGS) {
+      setGameState('won');
+    } else if (currentRow === ROWS - 1) {
+      setGameState('lost');
+    } else {
+      setCurrentRow(currentRow + 1);
+    }
+  }, [gameState, guesses, currentRow, secret, results]);
+
+  const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (gameState !== 'playing') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = CANVAS_WIDTH / rect.width;
+    const scaleY = CANVAS_HEIGHT / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+
+    const paletteY = TOP_MARGIN + ROW_SPACING * ROWS + 60;
+    const paletteStartX = (CANVAS_WIDTH - (COLORS.length - 1) * PALETTE_SPACING) / 2;
+    for (let i = 0; i < COLORS.length; i++) {
+      const cx = paletteStartX + i * PALETTE_SPACING;
+      const cy = paletteY;
+      const dist = Math.hypot(x - cx, y - cy);
+      if (dist <= PALETTE_RADIUS) {
+        const colIndex = guesses[currentRow].findIndex(v => v === -1);
+        if (colIndex !== -1) {
+          const newGuesses = guesses.map((r, ri) => {
+            if (ri !== currentRow) return r;
+            const newRow = [...r];
+            newRow[colIndex] = i;
+            return newRow;
+          });
+          setGuesses(newGuesses);
+        }
+        return;
+      }
+    }
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = CANVAS_WIDTH * dpr;
+    canvas.height = CANVAS_HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+    const gradient = ctx.createRadialGradient(
+      CANVAS_WIDTH / 2,
+      CANVAS_HEIGHT / 2,
+      0,
+      CANVAS_WIDTH / 2,
+      CANVAS_HEIGHT / 2,
+      Math.max(CANVAS_WIDTH, CANVAS_HEIGHT) / 1.5
+    );
+    gradient.addColorStop(0, '#15161a');
+    gradient.addColorStop(1, '#0f0f12');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const boardWidth = PEG_SPACING * PEGS + 60;
+    const startX = (CANVAS_WIDTH - boardWidth) / 2;
+
+    for (let r = 0; r < ROWS; r++) {
+      const y = TOP_MARGIN + r * ROW_SPACING;
+      for (let c = 0; c < PEGS; c++) {
+        const x = startX + c * PEG_SPACING;
+        ctx.beginPath();
+        ctx.arc(x, y, PEG_RADIUS, 0, Math.PI * 2);
+        const colorIndex = guesses[r][c];
+        ctx.fillStyle = colorIndex === -1 ? 'rgba(255,255,255,0.1)' : COLORS[colorIndex];
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+        ctx.stroke();
+      }
+
+      const res = results[r];
+      if (res) {
+        const fbX = startX + PEG_SPACING * PEGS + 20;
+        const fbY = y - FEEDBACK_SPACING / 2;
+        let peg = 0;
+        for (let i = 0; i < res.correct; i++) {
+          const fx = fbX + (peg % 2) * FEEDBACK_SPACING;
+          const fy = fbY + Math.floor(peg / 2) * FEEDBACK_SPACING;
+          ctx.beginPath();
+          ctx.arc(fx, fy, FEEDBACK_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = '#000';
+          ctx.fill();
+          peg++;
+        }
+        for (let i = 0; i < res.misplaced; i++) {
+          const fx = fbX + (peg % 2) * FEEDBACK_SPACING;
+          const fy = fbY + Math.floor(peg / 2) * FEEDBACK_SPACING;
+          ctx.beginPath();
+          ctx.arc(fx, fy, FEEDBACK_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = '#fff';
+          ctx.fill();
+          peg++;
+        }
+      }
+    }
+
+    const paletteY = TOP_MARGIN + ROW_SPACING * ROWS + 60;
+    const paletteStartX = (CANVAS_WIDTH - (COLORS.length - 1) * PALETTE_SPACING) / 2;
+    for (let i = 0; i < COLORS.length; i++) {
+      const x = paletteStartX + i * PALETTE_SPACING;
+      ctx.beginPath();
+      ctx.arc(x, paletteY, PALETTE_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS[i];
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+      ctx.stroke();
+    }
+
+    if (gameState === 'won' || gameState === 'lost') {
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      const msg = gameState === 'won'
+        ? '정답입니다!'
+        : `실패! 정답: ${secret.map(i => COLOR_NAMES[i]).join(', ')}`;
+      ctx.fillText(msg, CANVAS_WIDTH / 2, 30);
+    }
+  }, [guesses, results, secret, gameState]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['w', 'a', 's', 'd', 'r', 'z'].includes(key)) {
+        e.stopPropagation();
+      }
+      if (key === 'r') {
+        e.preventDefault();
+        resetGame();
+      } else if (key === 'z') {
+        e.preventDefault();
+        handleUndo();
+      }
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [resetGame, handleUndo]);
+
+  return (
+    <GameLayout
+      title="🧠 Mastermind"
+      topInfo={<div>시도: {currentRow + 1}/{ROWS}</div>}
+      bottomInfo={<div>팔레트에서 색을 선택해 조합을 맞추세요. Submit으로 확인, Z=Undo, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Mastermind"
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        onClick={handleCanvasClick}
+      />
+      <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
+        <GameButton
+          onClick={submitGuess}
+          disabled={guesses[currentRow].some(v => v === -1) || gameState !== 'playing'}
+        >
+          Submit
+        </GameButton>
+        <GameButton
+          onClick={handleUndo}
+          variant="secondary"
+          disabled={guesses[currentRow].every(v => v === -1) || gameState !== 'playing'}
+        >
+          Undo
+        </GameButton>
+        <GameButton onClick={resetGame} variant="secondary">
+          Reset
+        </GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MastermindCanvas;
+

--- a/src/MatchThreeCanvas.tsx
+++ b/src/MatchThreeCanvas.tsx
@@ -1,0 +1,186 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 8;
+const COLORS = ['#ff595e', '#1982c4', '#6a4c93', '#8ac926', '#ffca3a', '#ff924c'];
+const TILE = 60;
+const WIDTH = SIZE * TILE;
+const HEIGHT = WIDTH;
+
+type Board = number[][];
+
+const randomGem = () => Math.floor(Math.random() * COLORS.length);
+
+function findMatches(board: Board) {
+  const matches = new Set<string>();
+  // rows
+  for (let r = 0; r < SIZE; r++) {
+    let runColor = board[r][0];
+    let runStart = 0;
+    for (let c = 1; c <= SIZE; c++) {
+      if (c < SIZE && board[r][c] === runColor) continue;
+      if (runColor !== -1 && c - runStart >= 3) {
+        for (let i = runStart; i < c; i++) matches.add(`${r},${i}`);
+      }
+      runColor = c < SIZE ? board[r][c] : -1;
+      runStart = c;
+    }
+  }
+  // columns
+  for (let c = 0; c < SIZE; c++) {
+    let runColor = board[0][c];
+    let runStart = 0;
+    for (let r = 1; r <= SIZE; r++) {
+      if (r < SIZE && board[r][c] === runColor) continue;
+      if (runColor !== -1 && r - runStart >= 3) {
+        for (let i = runStart; i < r; i++) matches.add(`${i},${c}`);
+      }
+      runColor = r < SIZE ? board[r][c] : -1;
+      runStart = r;
+    }
+  }
+  return Array.from(matches).map(s => s.split(',').map(Number) as [number, number]);
+}
+
+function resolveBoard(board: Board) {
+  let removed = 0;
+  while (true) {
+    const matches = findMatches(board);
+    if (matches.length === 0) break;
+    removed += matches.length;
+    for (const [r, c] of matches) board[r][c] = -1;
+    for (let c = 0; c < SIZE; c++) {
+      let dest = SIZE - 1;
+      for (let r = SIZE - 1; r >= 0; r--) {
+        if (board[r][c] !== -1) {
+          board[dest][c] = board[r][c];
+          dest--;
+        }
+      }
+      for (let r = dest; r >= 0; r--) {
+        board[r][c] = randomGem();
+      }
+    }
+  }
+  return removed;
+}
+
+function createBoard(): Board {
+  const board = Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, randomGem));
+  resolveBoard(board);
+  return board;
+}
+
+const MatchThreeCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [board, setBoard] = useState<Board>(() => createBoard());
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+  const [score, setScore] = useState(0);
+
+  const resetGame = useCallback(() => {
+    setBoard(createBoard());
+    setSelected(null);
+    setScore(0);
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / TILE);
+      const r = Math.floor(y / TILE);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      if (!selected) {
+        setSelected([r, c]);
+        return;
+      }
+      const [sr, sc] = selected;
+      if (sr === r && sc === c) {
+        setSelected(null);
+        return;
+      }
+      if (Math.abs(sr - r) + Math.abs(sc - c) !== 1) {
+        setSelected([r, c]);
+        return;
+      }
+      const newBoard = board.map(row => row.slice());
+      [newBoard[sr][sc], newBoard[r][c]] = [newBoard[r][c], newBoard[sr][sc]];
+      const cleared = resolveBoard(newBoard);
+      if (cleared > 0) {
+        setScore(s => s + cleared);
+        setBoard(newBoard);
+      } else {
+        [newBoard[sr][sc], newBoard[r][c]] = [newBoard[r][c], newBoard[sr][sc]];
+        setBoard(newBoard);
+      }
+      setSelected(null);
+    },
+    [board, selected]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const colorIndex = board[r][c];
+        ctx.fillStyle = colorIndex >= 0 ? COLORS[colorIndex] : '#000';
+        ctx.fillRect(c * TILE, r * TILE, TILE, TILE);
+        ctx.strokeStyle = '#111';
+        ctx.strokeRect(c * TILE, r * TILE, TILE, TILE);
+      }
+    }
+    if (selected) {
+      const [r, c] = selected;
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(c * TILE + 2, r * TILE + 2, TILE - 4, TILE - 4);
+    }
+  }, [board, selected]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="💎 Match-3"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>인접한 보석을 클릭해 교환하세요. 3개 이상 매치하면 제거됩니다. R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Match-3"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MatchThreeCanvas;
+

--- a/src/MinesweeperCanvas.tsx
+++ b/src/MinesweeperCanvas.tsx
@@ -1,0 +1,208 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 10;
+const MINES = 10;
+const CELL = 32;
+const WIDTH = SIZE * CELL;
+const HEIGHT = SIZE * CELL;
+
+interface Cell {
+  mine: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  adjacent: number;
+}
+
+function createBoard(): Cell[][] {
+  const board: Cell[][] = Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, () => ({ mine: false, revealed: false, flagged: false, adjacent: 0 }))
+  );
+  let placed = 0;
+  while (placed < MINES) {
+    const r = Math.floor(Math.random() * SIZE);
+    const c = Math.floor(Math.random() * SIZE);
+    if (board[r][c].mine) continue;
+    board[r][c].mine = true;
+    placed++;
+  }
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      if (board[r][c].mine) continue;
+      let count = 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const nr = r + dr;
+          const nc = c + dc;
+          if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) continue;
+          if (board[nr][nc].mine) count++;
+        }
+      }
+      board[r][c].adjacent = count;
+    }
+  }
+  return board;
+}
+
+const MinesweeperCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [board, setBoard] = useState<Cell[][]>(() => createBoard());
+  const [state, setState] = useState<'playing' | 'won' | 'lost'>('playing');
+  const [flags, setFlags] = useState(0);
+
+  const resetGame = useCallback(() => {
+    setBoard(createBoard());
+    setState('playing');
+    setFlags(0);
+  }, []);
+
+  const flood = useCallback((b: Cell[][], r: number, c: number) => {
+    const cell = b[r][c];
+    if (cell.revealed || cell.flagged) return;
+    cell.revealed = true;
+    if (cell.mine) {
+      setState('lost');
+      return;
+    }
+    if (cell.adjacent === 0) {
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const nr = r + dr;
+          const nc = c + dc;
+          if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) continue;
+          flood(b, nr, nc);
+        }
+      }
+    }
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      const newBoard = board.map(row => row.map(cell => ({ ...cell })));
+      flood(newBoard, r, c);
+      const cleared = newBoard.every(row => row.every(cell => cell.revealed || cell.mine));
+      if (cleared && state === 'playing') setState('won');
+      setBoard(newBoard);
+    },
+    [board, flood, state]
+  );
+
+  const handleRightClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      const newBoard = board.map(row => row.map(cell => ({ ...cell })));
+      const cell = newBoard[r][c];
+      if (cell.revealed) return;
+      cell.flagged = !cell.flagged;
+      setFlags(f => f + (cell.flagged ? 1 : -1));
+      setBoard(newBoard);
+    },
+    [board, state]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const cell = board[r][c];
+        const x = c * CELL;
+        const y = r * CELL;
+        ctx.strokeStyle = '#555';
+        ctx.strokeRect(x, y, CELL, CELL);
+        if (cell.revealed) {
+          ctx.fillStyle = '#333';
+          ctx.fillRect(x, y, CELL, CELL);
+          if (cell.mine) {
+            ctx.fillStyle = 'red';
+            ctx.beginPath();
+            ctx.arc(x + CELL / 2, y + CELL / 2, CELL / 4, 0, Math.PI * 2);
+            ctx.fill();
+          } else if (cell.adjacent > 0) {
+            ctx.fillStyle = '#fff';
+            ctx.font = '16px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(String(cell.adjacent), x + CELL / 2, y + CELL / 2);
+          }
+        } else {
+          ctx.fillStyle = '#444';
+          ctx.fillRect(x, y, CELL, CELL);
+          if (cell.flagged) {
+            ctx.fillStyle = 'yellow';
+            ctx.beginPath();
+            ctx.moveTo(x + CELL * 0.3, y + CELL * 0.7);
+            ctx.lineTo(x + CELL * 0.5, y + CELL * 0.3);
+            ctx.lineTo(x + CELL * 0.7, y + CELL * 0.7);
+            ctx.closePath();
+            ctx.fill();
+          }
+        }
+      }
+    }
+    if (state === 'won' || state === 'lost') {
+      ctx.fillStyle = '#fff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      const msg = state === 'won' ? '승리!' : '실패!';
+      ctx.fillText(msg, WIDTH / 2, HEIGHT / 2);
+    }
+  }, [board, state]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="💣 Minesweeper"
+      topInfo={<div>Flags: {flags}/{MINES}</div>}
+      bottomInfo={<div>좌클릭: 열기, 우클릭: 깃발, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Minesweeper"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MinesweeperCanvas;

--- a/src/PicrossCanvas.tsx
+++ b/src/PicrossCanvas.tsx
@@ -1,0 +1,217 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 10;
+const CELL = 32;
+const HINT = 40;
+const WIDTH = HINT + SIZE * CELL;
+const HEIGHT = HINT + SIZE * CELL;
+
+type CellState = 0 | 1 | 2; // empty, filled, marked
+
+function createPuzzle(): boolean[][] {
+  return Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, () => Math.random() < 0.5)
+  );
+}
+
+function createBoard(): CellState[][] {
+  return Array.from({ length: SIZE }, () => Array<CellState>(SIZE).fill(0));
+}
+
+function computeHints(puzzle: boolean[][]) {
+  const rows = puzzle.map((row) => {
+    const hints: number[] = [];
+    let count = 0;
+    for (const cell of row) {
+      if (cell) count++;
+      else if (count) {
+        hints.push(count);
+        count = 0;
+      }
+    }
+    if (count) hints.push(count);
+    return hints.length ? hints : [0];
+  });
+  const cols = Array.from({ length: SIZE }, (_, c) => {
+    const hints: number[] = [];
+    let count = 0;
+    for (let r = 0; r < SIZE; r++) {
+      if (puzzle[r][c]) count++;
+      else if (count) {
+        hints.push(count);
+        count = 0;
+      }
+    }
+    if (count) hints.push(count);
+    return hints.length ? hints : [0];
+  });
+  return { rows, cols };
+}
+
+const PicrossCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [puzzle, setPuzzle] = useState<boolean[][]>(() => createPuzzle());
+  const [board, setBoard] = useState<CellState[][]>(() => createBoard());
+  const [hints, setHints] = useState(() => computeHints(puzzle));
+  const [state, setState] = useState<'playing' | 'won'>('playing');
+
+  const resetGame = useCallback(() => {
+    const p = createPuzzle();
+    setPuzzle(p);
+    setBoard(createBoard());
+    setHints(computeHints(p));
+    setState('playing');
+  }, []);
+
+  const checkWin = useCallback((b: CellState[][], p: boolean[][]) => {
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const filled = b[r][c] === 1;
+        if (filled !== p[r][c]) return false;
+      }
+    }
+    return true;
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH - HINT;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT - HINT;
+      if (x < 0 || y < 0) return;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      const newBoard = board.map((row) => row.slice());
+      newBoard[r][c] = newBoard[r][c] === 1 ? 0 : 1;
+      if (checkWin(newBoard, puzzle)) setState('won');
+      setBoard(newBoard);
+    },
+    [board, checkWin, puzzle, state]
+  );
+
+  const handleRightClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH - HINT;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT - HINT;
+      if (x < 0 || y < 0) return;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      const newBoard = board.map((row) => row.slice());
+      newBoard[r][c] = newBoard[r][c] === 2 ? 0 : 2;
+      setBoard(newBoard);
+    },
+    [board, state]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // draw hints
+    ctx.fillStyle = '#fff';
+    ctx.font = '14px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let r = 0; r < SIZE; r++) {
+      const rowHints = hints.rows[r];
+      for (let i = 0; i < rowHints.length; i++) {
+        const num = rowHints[rowHints.length - 1 - i];
+        ctx.fillText(String(num), HINT - 4 - i * 14, HINT + r * CELL + CELL / 2);
+      }
+    }
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    for (let c = 0; c < SIZE; c++) {
+      const colHints = hints.cols[c];
+      for (let i = 0; i < colHints.length; i++) {
+        const num = colHints[colHints.length - 1 - i];
+        ctx.fillText(String(num), HINT + c * CELL + CELL / 2, HINT - 4 - i * 14);
+      }
+    }
+
+    // draw grid and cells
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const x = HINT + c * CELL;
+        const y = HINT + r * CELL;
+        ctx.strokeStyle = '#555';
+        ctx.strokeRect(x, y, CELL, CELL);
+        const val = board[r][c];
+        if (val === 1) {
+          ctx.fillStyle = '#fff';
+          ctx.fillRect(x + 2, y + 2, CELL - 4, CELL - 4);
+        } else if (val === 2) {
+          ctx.strokeStyle = '#888';
+          ctx.beginPath();
+          ctx.moveTo(x + 4, y + 4);
+          ctx.lineTo(x + CELL - 4, y + CELL - 4);
+          ctx.moveTo(x + CELL - 4, y + 4);
+          ctx.lineTo(x + 4, y + CELL - 4);
+          ctx.stroke();
+        } else {
+          ctx.fillStyle = '#333';
+          ctx.fillRect(x + 1, y + 1, CELL - 2, CELL - 2);
+        }
+      }
+    }
+
+    if (state === 'won') {
+      ctx.fillStyle = '#fff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('완료!', WIDTH / 2, HEIGHT / 2);
+    }
+  }, [board, hints, state]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="🖼️ Picross"
+      bottomInfo={<div>좌클릭: 칸 채우기, 우클릭: X, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Picross"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default PicrossCanvas;

--- a/src/SlidePuzzleCanvas.tsx
+++ b/src/SlidePuzzleCanvas.tsx
@@ -15,8 +15,10 @@ interface GameStats {
 
 const GRID_SIZE = 4;
 const CANVAS_SIZE = 480;
-const TILE_SIZE = (CANVAS_SIZE - 50) / GRID_SIZE;
 const TILE_GAP = 10;
+const TILE_SIZE = (CANVAS_SIZE - (GRID_SIZE + 1) * TILE_GAP) / GRID_SIZE;
+const BOARD_SIZE = GRID_SIZE * TILE_SIZE + (GRID_SIZE - 1) * TILE_GAP;
+const START = (CANVAS_SIZE - BOARD_SIZE) / 2;
 
 // 타일 색상
 const TILE_COLORS = {
@@ -163,8 +165,8 @@ const SlidePuzzleCanvas: React.FC = () => {
 
   // 캔버스에서 클릭된 타일 인덱스 계산
   const getTileFromPosition = useCallback((x: number, y: number): number | null => {
-    const startX = 25;
-    const startY = 25;
+    const startX = START;
+    const startY = START;
     
     const col = Math.floor((x - startX) / (TILE_SIZE + TILE_GAP));
     const row = Math.floor((y - startY) / (TILE_SIZE + TILE_GAP));
@@ -263,14 +265,14 @@ const SlidePuzzleCanvas: React.FC = () => {
 
     // 그리드 배경
     ctx.fillStyle = '#E9ECEF';
-    ctx.fillRect(15, 15, CANVAS_SIZE - 30, CANVAS_SIZE - 30);
+    ctx.fillRect(START, START, BOARD_SIZE, BOARD_SIZE);
 
     // 타일 그리기
     for (let i = 0; i < 16; i++) {
       const row = Math.floor(i / GRID_SIZE);
       const col = i % GRID_SIZE;
-      const x = 25 + col * (TILE_SIZE + TILE_GAP);
-      const y = 25 + row * (TILE_SIZE + TILE_GAP);
+      const x = START + col * (TILE_SIZE + TILE_GAP);
+      const y = START + row * (TILE_SIZE + TILE_GAP);
       const value = puzzle[i];
       
       if (value === 16) continue; // 빈 칸은 그리지 않음

--- a/src/SpaceInvadersCanvas.tsx
+++ b/src/SpaceInvadersCanvas.tsx
@@ -1,0 +1,229 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+// Use shared layout width so the game matches the rest of the catalog
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const PLAYER_WIDTH = 60;
+const PLAYER_HEIGHT = 20;
+const PLAYER_SPEED = 300; // px per second
+const BULLET_SPEED = 500;
+const ALIEN_ROWS = 5;
+const ALIEN_COLS = 8;
+const ALIEN_WIDTH = 40;
+const ALIEN_HEIGHT = 30;
+const ALIEN_GAP = 10;
+const ALIEN_X_SPEED = 40;
+const ALIEN_DROP = 20;
+
+interface Bullet {
+  x: number;
+  y: number;
+}
+
+interface Alien {
+  x: number;
+  y: number;
+  alive: boolean;
+}
+
+const SpaceInvadersCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const lastTimeRef = useRef<number>(0);
+  const keysRef = useRef<Set<string>>(new Set());
+  const bulletsRef = useRef<Bullet[]>([]);
+  const aliensRef = useRef<Alien[]>([]);
+  const directionRef = useRef(1);
+  const playerXRef = useRef(CANVAS_WIDTH / 2 - PLAYER_WIDTH / 2);
+
+  const [score, setScore] = useState(0);
+  const [gameState, setGameState] = useState<'playing' | 'won' | 'gameover'>('playing');
+
+  const initAliens = useCallback(() => {
+    const aliens: Alien[] = [];
+    const startX = (CANVAS_WIDTH - (ALIEN_COLS * (ALIEN_WIDTH + ALIEN_GAP) - ALIEN_GAP)) / 2;
+    for (let r = 0; r < ALIEN_ROWS; r++) {
+      for (let c = 0; c < ALIEN_COLS; c++) {
+        aliens.push({
+          x: startX + c * (ALIEN_WIDTH + ALIEN_GAP),
+          y: 60 + r * (ALIEN_HEIGHT + ALIEN_GAP),
+          alive: true
+        });
+      }
+    }
+    aliensRef.current = aliens;
+  }, []);
+
+  const startGame = useCallback(() => {
+    setScore(0);
+    setGameState('playing');
+    playerXRef.current = CANVAS_WIDTH / 2 - PLAYER_WIDTH / 2;
+    bulletsRef.current = [];
+    directionRef.current = 1;
+    initAliens();
+  }, [initAliens]);
+
+  const update = useCallback((dt: number) => {
+    if (gameState !== 'playing') return;
+
+    // player movement
+    if (keysRef.current.has('ArrowLeft') || keysRef.current.has('KeyA')) {
+      playerXRef.current = Math.max(0, playerXRef.current - PLAYER_SPEED * dt);
+    }
+    if (keysRef.current.has('ArrowRight') || keysRef.current.has('KeyD')) {
+      playerXRef.current = Math.min(CANVAS_WIDTH - PLAYER_WIDTH, playerXRef.current + PLAYER_SPEED * dt);
+    }
+
+    // bullets
+    bulletsRef.current = bulletsRef.current.filter(b => {
+      b.y -= BULLET_SPEED * dt;
+      return b.y > -10;
+    });
+
+    // aliens
+    let hitEdge = false;
+    aliensRef.current.forEach(alien => {
+      if (!alien.alive) return;
+      alien.x += directionRef.current * ALIEN_X_SPEED * dt;
+      if (alien.x < 20 || alien.x + ALIEN_WIDTH > CANVAS_WIDTH - 20) {
+        hitEdge = true;
+      }
+    });
+    if (hitEdge) {
+      directionRef.current *= -1;
+      aliensRef.current.forEach(a => (a.y += ALIEN_DROP));
+    }
+
+    // collisions
+    bulletsRef.current.forEach(b => {
+      aliensRef.current.forEach(a => {
+        if (a.alive && b.x > a.x && b.x < a.x + ALIEN_WIDTH && b.y > a.y && b.y < a.y + ALIEN_HEIGHT) {
+          a.alive = false;
+          b.y = -20;
+          setScore(s => s + 10);
+        }
+      });
+    });
+
+    // win/lose check
+    const playerY = CANVAS_HEIGHT - PLAYER_HEIGHT - 10;
+    if (aliensRef.current.every(a => !a.alive)) {
+      setGameState('won');
+    } else if (aliensRef.current.some(a => a.alive && a.y + ALIEN_HEIGHT >= playerY)) {
+      setGameState('gameover');
+    }
+  }, [gameState]);
+
+  const draw = useCallback((ctx: CanvasRenderingContext2D) => {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const playerY = CANVAS_HEIGHT - PLAYER_HEIGHT - 10;
+    ctx.fillStyle = '#00ff00';
+    ctx.fillRect(playerXRef.current, playerY, PLAYER_WIDTH, PLAYER_HEIGHT);
+
+    ctx.fillStyle = '#ffff00';
+    bulletsRef.current.forEach(b => {
+      ctx.fillRect(b.x - 2, b.y, 4, 10);
+    });
+
+    ctx.fillStyle = '#ff4444';
+    aliensRef.current.forEach(a => {
+      if (a.alive) ctx.fillRect(a.x, a.y, ALIEN_WIDTH, ALIEN_HEIGHT);
+    });
+
+    ctx.fillStyle = '#fff';
+    ctx.font = '20px Arial';
+    ctx.fillText(`Score: ${score}`, 20, 30);
+
+    if (gameState === 'gameover' || gameState === 'won') {
+      ctx.fillStyle = 'rgba(0,0,0,0.7)';
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+      ctx.textAlign = 'center';
+      ctx.fillStyle = gameState === 'won' ? '#00ff00' : '#ff4444';
+      ctx.font = '48px Arial';
+      ctx.fillText(gameState === 'won' ? 'YOU WIN!' : 'GAME OVER', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+      ctx.fillStyle = '#fff';
+      ctx.font = '24px Arial';
+      ctx.fillText('Press R to Restart', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 40);
+      ctx.textAlign = 'left';
+    }
+  }, [score, gameState]);
+
+  const loop = useCallback((time: number) => {
+    const dt = (time - lastTimeRef.current) / 1000;
+    lastTimeRef.current = time;
+    update(dt);
+    const ctx = canvasRef.current?.getContext('2d');
+    if (ctx) draw(ctx);
+    animationRef.current = requestAnimationFrame(loop);
+  }, [update, draw]);
+
+  useEffect(() => {
+    startGame();
+  }, [startGame]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (['ArrowLeft', 'ArrowRight', 'KeyA', 'KeyD', 'Space', 'KeyR'].includes(e.code)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      keysRef.current.add(e.code);
+      if (e.code === 'Space' && gameState === 'playing') {
+        bulletsRef.current.push({ x: playerXRef.current + PLAYER_WIDTH / 2, y: CANVAS_HEIGHT - PLAYER_HEIGHT - 15 });
+      }
+      if (e.code === 'KeyR' && gameState !== 'playing') {
+        startGame();
+      }
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(e.code);
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    window.addEventListener('keyup', handleKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
+      window.removeEventListener('keyup', handleKeyUp, { capture: true });
+    };
+  }, [gameState, startGame]);
+
+  useEffect(() => {
+    animationRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [loop]);
+
+  const gameStats = <div>점수: {score}</div>;
+  const instructions = '←/→ 또는 A/D 이동, Space 발사, R 재시작';
+  const actionButtons = (
+    <GameButton onClick={startGame} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  return (
+    <GameManager
+      title="Space Invaders"
+      gameIcon="👾"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        gameTitle="Space Invaders"
+      />
+    </GameManager>
+  );
+};
+
+export default SpaceInvadersCanvas;
+

--- a/src/WhackAMoleCanvas.tsx
+++ b/src/WhackAMoleCanvas.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameButton from './components/GameButton';
+
+const GRID_SIZE = 3;
+const GAME_TIME = 30; // seconds
+const SPAWN_INTERVAL = 800; // ms
+
+const WhackAMoleCanvas: React.FC = () => {
+  const [score, setScore] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(GAME_TIME);
+  const [active, setActive] = useState<number | null>(null);
+  const [running, setRunning] = useState(true);
+
+  // 두더지 출현 타이머
+  useEffect(() => {
+    if (!running) return;
+    const moleTimer = setInterval(() => {
+      setActive(Math.floor(Math.random() * GRID_SIZE * GRID_SIZE));
+    }, SPAWN_INTERVAL);
+    return () => clearInterval(moleTimer);
+  }, [running]);
+
+  // 게임 시간 카운트다운
+  useEffect(() => {
+    if (!running) return;
+    if (timeLeft <= 0) {
+      setRunning(false);
+      setActive(null);
+      return;
+    }
+    const timer = setTimeout(() => setTimeLeft(t => t - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [timeLeft, running]);
+
+  const whack = useCallback((index: number) => {
+    if (!running) return;
+    if (index === active) {
+      setScore(s => s + 1);
+      setActive(null);
+    }
+  }, [active, running]);
+
+  const reset = () => {
+    setScore(0);
+    setTimeLeft(GAME_TIME);
+    setRunning(true);
+  };
+
+  const gridSize = 100;
+  const grid = (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${GRID_SIZE}, ${gridSize}px)`,
+        gap: 8,
+        justifyContent: 'center'
+      }}
+    >
+      {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, i) => (
+        <div
+          key={i}
+          onClick={() => whack(i)}
+          style={{
+            width: gridSize,
+            height: gridSize,
+            background: '#444',
+            borderRadius: 8,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            userSelect: 'none'
+          }}
+        >
+          {active === i && (
+            <div
+              style={{
+                width: gridSize * 0.6,
+                height: gridSize * 0.6,
+                borderRadius: '50%',
+                background: '#8B4513'
+              }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  const gameStats = (
+    <div style={{ textAlign: 'center', color: '#bcbcbe' }}>
+      <div>점수: {score}</div>
+      <div>남은 시간: {timeLeft}s</div>
+    </div>
+  );
+
+  const actionButtons = (
+    <GameButton onClick={reset} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  const instructions = '두더지를 클릭해 점수를 올리세요! 30초 동안 최대한 많이 잡으세요.';
+
+  return (
+    <GameManager
+      title="Whack-a-Mole"
+      gameIcon="🐹"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      {grid}
+    </GameManager>
+  );
+};
+
+export default WhackAMoleCanvas;

--- a/src/components/GameManager.tsx
+++ b/src/components/GameManager.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { spacing, typography, colors } from '../theme/gameTheme';
+import { spacing, typography, colors, layout } from '../theme/gameTheme';
 
 interface GameManagerProps {
   // 게임 식별 정보
@@ -92,25 +92,29 @@ const GameManager: React.FC<GameManagerProps> = ({
       </button>
 
       {/* 메인 게임 영역 - 중앙 정렬 */}
-      <div style={{
-        width: '100%',
-        maxWidth: '1200px',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: spacing.xl
-      }}>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: layout.maxWidth,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: spacing.xl,
+        }}
+      >
         
         {/* 상단 영역 - 파란색 박스 (게임 상태/점수) */}
-        <div style={{
-          background: colors.panelBackground,
-          borderRadius: 12,
-          padding: spacing.lg,
-          width: '100%',
-          maxWidth: '800px',
-          border: `2px solid ${colors.accent}`,
-          boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
-        }}>
+        <div
+          style={{
+            background: colors.panelBackground,
+            borderRadius: 12,
+            padding: spacing.lg,
+            width: '100%',
+            maxWidth: layout.maxWidth,
+            border: `2px solid ${colors.accent}`,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+          }}
+        >
           {/* 게임 타이틀 */}
           <div style={{
             textAlign: 'center',
@@ -149,29 +153,35 @@ const GameManager: React.FC<GameManagerProps> = ({
         </div>
 
         {/* 중앙 게임 캔버스 영역 - 빨간색 박스 */}
-        <div style={{
-          background: colors.canvasBackground,
-          borderRadius: 16,
-          padding: spacing.md,
-          border: `2px solid ${colors.canvasBorder}`,
-          boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center'
-        }}>
+        <div
+          style={{
+            background: colors.canvasBackground,
+            borderRadius: 16,
+            padding: spacing.md,
+            border: `2px solid ${colors.canvasBorder}`,
+            boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%',
+            maxWidth: layout.maxWidth,
+          }}
+        >
           {children}
         </div>
 
         {/* 하단 영역 - 녹색 박스 (조작법/기능 버튼) */}
-        <div style={{
-          background: colors.panelBackground,
-          borderRadius: 12,
-          padding: spacing.lg,
-          width: '100%',
-          maxWidth: '800px',
-          border: `2px solid ${colors.success}`,
-          boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
-        }}>
+        <div
+          style={{
+            background: colors.panelBackground,
+            borderRadius: 12,
+            padding: spacing.lg,
+            width: '100%',
+            maxWidth: layout.maxWidth,
+            border: `2px solid ${colors.success}`,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+          }}
+        >
           
           {/* 조작법 */}
           {instructions && (

--- a/src/components/GameMenu.tsx
+++ b/src/components/GameMenu.tsx
@@ -1,62 +1,59 @@
-import React from "react";
-
-export type GameId = "menu" | "pingpong" | "tetris" | "snake" | "omok" | "lightsout" | "simon" | "reaction" | "aim" | "breakout" | "flappy" | "memory" | "dodge" | "2048" | "slide" | "sokoban" | "connect4" | "minigolf" | "tictactoe";
+import React from 'react';
+import { GameDefinition, GameId } from '../games';
 
 type Props = {
-  onSelect: (id: Exclude<GameId, "menu">) => void;
+  games: readonly GameDefinition[];
+  onSelect: (id: GameId) => void;
 };
 
-export default function GameMenu({ onSelect }: Props) {
-  const Card: React.FC<{
-    title: string;
-    desc: string;
-    onClick: () => void;
-  }> = ({ title, desc, onClick }) => (
+export default function GameMenu({ games, onSelect }: Props) {
+  const Card: React.FC<{ title: string; desc: string; onClick: () => void }> = ({
+    title,
+    desc,
+    onClick,
+  }) => (
     <button
       onClick={onClick}
       style={{
-        display: "grid",
+        display: 'grid',
         gap: 8,
-        textAlign: "left",
-        background:
-          "linear-gradient(180deg, rgba(35,36,42,.9), rgba(27,28,33,.9))",
-        border: "1px solid rgba(255,255,255,.08)",
+        textAlign: 'left',
+        background: 'linear-gradient(180deg, rgba(35,36,42,.9), rgba(27,28,33,.9))',
+        border: '1px solid rgba(255,255,255,.08)',
         borderRadius: 14,
         padding: 16,
         width: 280,
-        cursor: "pointer",
+        cursor: 'pointer',
         boxShadow:
-          "0 10px 30px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.03)",
-        color: "#e8e8ea",
+          '0 10px 30px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.03)',
+        color: '#e8e8ea',
       }}
     >
       <div style={{ fontWeight: 800, fontSize: 18 }}>{title}</div>
-      <div style={{ fontSize: 13, color: "#bcbcbe", lineHeight: 1.35 }}>
-        {desc}
-      </div>
+      <div style={{ fontSize: 13, color: '#bcbcbe', lineHeight: 1.35 }}>{desc}</div>
     </button>
   );
 
   return (
     <div
       style={{
-        minHeight: "100vh",
-        background: "#0f0f12",
-        color: "#e8e8ea",
-        display: "grid",
-        placeItems: "center",
+        minHeight: '100vh',
+        background: '#0f0f12',
+        color: '#e8e8ea',
+        display: 'grid',
+        placeItems: 'center',
         fontFamily:
           'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans KR", sans-serif',
         padding: 24,
       }}
     >
-      <div style={{ display: "grid", gap: 18, placeItems: "center" }}>
+      <div style={{ display: 'grid', gap: 18, placeItems: 'center' }}>
         <div
           style={{
             fontWeight: 900,
             fontSize: 28,
-            letterSpacing: ".4px",
-            textAlign: "center",
+            letterSpacing: '.4px',
+            textAlign: 'center',
           }}
         >
           🎮 미니 게임 모음
@@ -64,114 +61,38 @@ export default function GameMenu({ onSelect }: Props) {
 
         <div
           style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
             gap: 16,
-            alignItems: "stretch",
-            width: "min(880px, 92vw)",
+            alignItems: 'stretch',
+            width: 'min(880px, 92vw)',
           }}
         >
-          <Card
-            title="🏓 Ping Pong"
-            desc="마우스/키보드로 패들을 조작해 AI와 대결해요."
-            onClick={() => onSelect("pingpong")}
-          />
-          <Card
-            title="🧱 Tetris"
-            desc="회전/드랍/홀드로 라인을 지우며 점수를 올려요."
-            onClick={() => onSelect("tetris")}
-          />
-          <Card
-            title="🐍 Snake"
-            desc="먹이를 먹고 길어지세요. 벽/몸에 부딪히면 게임 오버!"
-            onClick={() => onSelect("snake")}
-          />
-          <Card
-            title="○● Omok"
-            desc="번갈아 돌을 놓아 다섯 줄을 만들어요."
-            onClick={() => onSelect("omok")}
-          />
-          <Card
-            title="💡 Lights Out"
-            desc="모든 불을 끄세요! 셀을 누르면 상하좌우가 토글됩니다."
-            onClick={() => onSelect("lightsout")}
-          />
-          <Card
-            title="🎨 Simon Says"
-            desc="점점 길어지는 색상 패턴을 기억해서 따라하세요!"
-            onClick={() => onSelect("simon")}
-          />
-          <Card
-            title="⚡ Reaction Test"
-            desc="화면이 초록색으로 바뀌는 순간 클릭! 반응속도를 테스트하세요."
-            onClick={() => onSelect("reaction")}
-          />
-          <Card
-            title="🎯 Aim Trainer"
-            desc="나타나는 원 타격을 븠르게 클릭! 마우스 정확도를 향상시켜요."
-            onClick={() => onSelect("aim")}
-          />
-          <Card
-            title="🧱 Breakout"
-            desc="공과 패들로 벽돌을 부수세요! 물리 충돌과 반사를 느껴보세요."
-            onClick={() => onSelect("breakout")}
-          />
-          <Card
-            title="🐦 Flappy Bird"
-            desc="점프해서 파이프 사이를 통과하세요! 중력과 가속도를 마스터하세요."
-            onClick={() => onSelect("flappy")}
-          />
-          <Card
-            title="🧠 Memory Cards"
-            desc="같은 그림의 카드 2장을 찾아서 매칭하세요! 기억력과 집중력을 테스트해보세요."
-            onClick={() => onSelect("memory")}
-          />
-          <Card
-            title="🚫 Dodge Game"
-            desc="WASD로 이동해서 떨어지는 블록을 피하세요! 시간이 지날수록 난이도가 증가합니다."
-            onClick={() => onSelect("dodge")}
-          />
-          <Card
-            title="🔢 2048"
-            desc="같은 숫자 타일을 슬라이드해서 합치고 2048을 만드세요! 전략적 사고가 필요합니다."
-            onClick={() => onSelect("2048")}
-          />
-          <Card
-            title="🧩 Slide Puzzle"
-            desc="빈 칸과 인접한 타일을 슬라이드하여 1~15 순서로 정렬하세요! 클래식 15퍼즐입니다."
-            onClick={() => onSelect("slide")}
-          />
-          <Card
-            title="🚚 Sokoban"
-            desc="박스를 목표 지점으로 밀어서 모든 퍼즐을 해결하세요! 되돌리기 기능과 5개 레벨 제공."
-            onClick={() => onSelect("sokoban")}
-          />
-          <Card
-            title="🔴 Connect Four"
-            desc="6x7 격자에서 4개 칩을 연속으로 연결하세요! AI와 대전하며 전략적 사고력을 기르세요."
-            onClick={() => onSelect("connect4")}
-          />
-          <Card
-            title="⛳ Mini Golf"
-            desc="드래그로 파워를 조절해서 골프공을 홀에 넣으세요! 물리 엔진과 벽 반사를 활용하세요."
-            onClick={() => onSelect("minigolf")}
-          />
-          <Card
-            title="⭕ Tic-Tac-Toe"
-            desc="X와 O를 번갈아 두며, 가로·세로·대각선으로 3개를 먼저 연결하면 승리! 클래식 틱택토 게임입니다."
-            onClick={() => onSelect("tictactoe")}
-          />
+          {games.map((g) => (
+            <Card
+              key={g.id}
+              title={g.title}
+              desc={g.description}
+              onClick={() => onSelect(g.id)}
+            />
+          ))}
         </div>
 
         <div
           style={{
             marginTop: 8,
             fontSize: 12,
-            color: "#a9a9ad",
-            textAlign: "center",
+            color: '#a9a9ad',
+            textAlign: 'center',
           }}
         >
-          Tip: 키보드 <b>1</b> = Ping Pong, <b>2</b> = Tetris, <b>3</b> = Snake, <b>4</b> = Omok, <b>5</b> = Lights Out, <b>6</b> = Simon Says, <b>7</b> = Reaction Test, <b>8</b> = Aim Trainer, <b>9</b> = Breakout, <b>0</b> = Flappy Bird, <b>T</b> = Tic-Tac-Toe
+          Tip:{' '}
+          {games.map((g, i) => (
+            <span key={g.id}>
+              <b>{g.hotkey.toUpperCase()}</b> = {g.tipName}
+              {i < games.length - 1 ? ', ' : ''}
+            </span>
+          ))}
         </div>
       </div>
     </div>

--- a/src/games.tsx
+++ b/src/games.tsx
@@ -1,0 +1,232 @@
+import React from 'react';
+import PingPongCanvas from './PingPongCanvas';
+import TetrisCanvas from './TetrisCanvas';
+import SnakeCanvas from './SnakeCanvas';
+import OmokCanvas from './OmokCanvas';
+import LightsOutCanvas from './LightsOutCanvas';
+import SimonSaysCanvas from './SimonSaysCanvas';
+import ReactionTestCanvas from './ReactionTestCanvas';
+import AimTrainerCanvas from './AimTrainerCanvas';
+import BreakoutCanvas from './BreakoutCanvas';
+import FlappyBirdCanvas from './FlappyBirdCanvas';
+import MemoryGameCanvas from './MemoryGameCanvas';
+import DodgeGameCanvas from './DodgeGameCanvas';
+import Game2048Canvas from './Game2048Canvas';
+import SlidePuzzleCanvas from './SlidePuzzleCanvas';
+import SokobanCanvas from './SokobanCanvas';
+import ConnectFourCanvas from './ConnectFourCanvas';
+import MiniGolfCanvas from './MiniGolfCanvas';
+import FroggerCanvas from './FroggerCanvas';
+import TicTacToeCanvas from './TicTacToeCanvas';
+import WhackAMoleCanvas from './WhackAMoleCanvas';
+import SpaceInvadersCanvas from './SpaceInvadersCanvas';
+import MastermindCanvas from './MastermindCanvas';
+import MinesweeperCanvas from './MinesweeperCanvas';
+import PicrossCanvas from './PicrossCanvas';
+import MatchThreeCanvas from './MatchThreeCanvas';
+
+export const games = [
+  {
+    id: 'pingpong',
+    title: '🏓 Ping Pong',
+    tipName: 'Ping Pong',
+    description: '마우스/키보드로 패들을 조작해 AI와 대결해요.',
+    hotkey: '1',
+    render: () => <PingPongCanvas width={900} height={540} />,
+  },
+  {
+    id: 'tetris',
+    title: '🧱 Tetris',
+    tipName: 'Tetris',
+    description: '회전/드랍/홀드로 라인을 지우며 점수를 올려요.',
+    hotkey: '2',
+    render: () => <TetrisCanvas />,
+  },
+  {
+    id: 'snake',
+    title: '🐍 Snake',
+    tipName: 'Snake',
+    description: '먹이를 먹고 길어지세요. 벽/몸에 부딪히면 게임 오버!',
+    hotkey: '3',
+    render: () => <SnakeCanvas />,
+  },
+  {
+    id: 'omok',
+    title: '○● Omok',
+    tipName: 'Omok',
+    description: '번갈아 돌을 놓아 다섯 줄을 만들어요.',
+    hotkey: '4',
+    render: () => <OmokCanvas />,
+  },
+  {
+    id: 'lightsout',
+    title: '💡 Lights Out',
+    tipName: 'Lights Out',
+    description: '모든 불을 끄세요! 셀을 누르면 상하좌우가 토글됩니다.',
+    hotkey: '5',
+    render: () => <LightsOutCanvas />,
+  },
+  {
+    id: 'simon',
+    title: '🎨 Simon Says',
+    tipName: 'Simon Says',
+    description: '점점 길어지는 색상 패턴을 기억해서 따라하세요!',
+    hotkey: '6',
+    render: () => <SimonSaysCanvas />,
+  },
+  {
+    id: 'reaction',
+    title: '⚡ Reaction Test',
+    tipName: 'Reaction Test',
+    description: '화면이 초록색으로 바뀌는 순간 클릭! 반응속도를 테스트하세요.',
+    hotkey: '7',
+    render: () => <ReactionTestCanvas />,
+  },
+  {
+    id: 'aim',
+    title: '🎯 Aim Trainer',
+    tipName: 'Aim Trainer',
+    description: '나타나는 원 타격을 빠르게 클릭! 마우스 정확도를 향상시켜요.',
+    hotkey: '8',
+    render: () => <AimTrainerCanvas />,
+  },
+  {
+    id: 'breakout',
+    title: '🧱 Breakout',
+    tipName: 'Breakout',
+    description: '공과 패들로 벽돌을 부수세요! 물리 충돌과 반사를 느껴보세요.',
+    hotkey: '9',
+    render: () => <BreakoutCanvas />,
+  },
+  {
+    id: 'flappy',
+    title: '🐦 Flappy Bird',
+    tipName: 'Flappy Bird',
+    description: '점프해서 파이프 사이를 통과하세요! 중력과 가속도를 마스터하세요.',
+    hotkey: '0',
+    render: () => <FlappyBirdCanvas />,
+  },
+  {
+    id: 'memory',
+    title: '🧠 Memory Cards',
+    tipName: 'Memory Cards',
+    description: '같은 그림의 카드 2장을 찾아서 매칭하세요! 기억력과 집중력을 테스트해보세요.',
+    hotkey: 'm',
+    render: () => <MemoryGameCanvas />,
+  },
+  {
+    id: 'dodge',
+    title: '🚫 Dodge Game',
+    tipName: 'Dodge Game',
+    description: 'WASD로 이동해서 떨어지는 블록을 피하세요! 시간이 지날수록 난이도가 증가합니다.',
+    hotkey: 'd',
+    render: () => <DodgeGameCanvas />,
+  },
+  {
+    id: '2048',
+    title: '🔢 2048',
+    tipName: '2048',
+    description: '같은 숫자 타일을 슬라이드해서 합치고 2048을 만드세요! 전략적 사고가 필요합니다.',
+    hotkey: '-',
+    render: () => <Game2048Canvas />,
+  },
+  {
+    id: 'slide',
+    title: '🧩 Slide Puzzle',
+    tipName: 'Slide Puzzle',
+    description: '빈 칸과 인접한 타일을 슬라이드하여 1~15 순서로 정렬하세요! 클래식 15퍼즐입니다.',
+    hotkey: '=',
+    render: () => <SlidePuzzleCanvas />,
+  },
+  {
+    id: 'sokoban',
+    title: '🚚 Sokoban',
+    tipName: 'Sokoban',
+    description: '박스를 목표 지점으로 밀어서 모든 퍼즐을 해결하세요! 되돌리기 기능과 5개 레벨 제공.',
+    hotkey: 's',
+    render: () => <SokobanCanvas />,
+  },
+  {
+    id: 'connect4',
+    title: '🔴 Connect Four',
+    tipName: 'Connect Four',
+    description: '6x7 격자에서 4개 칩을 연속으로 연결하세요! AI와 대전하며 전략적 사고력을 기르세요.',
+    hotkey: 'c',
+    render: () => <ConnectFourCanvas />,
+  },
+  {
+    id: 'minigolf',
+    title: '⛳ Mini Golf',
+    tipName: 'Mini Golf',
+    description: '드래그로 파워를 조절해서 골프공을 홀에 넣으세요! 물리 엔진과 벽 반사를 활용하세요.',
+    hotkey: 'g',
+    render: () => <MiniGolfCanvas />,
+  },
+  {
+    id: 'mastermind',
+    title: '🧠 Mastermind',
+    tipName: 'Mastermind',
+    description: '색 조합을 추리해 10번 안에 정답을 맞혀보세요!',
+    hotkey: 'h',
+    render: () => <MastermindCanvas />,
+  },
+  {
+    id: 'minesweeper',
+    title: '💣 Minesweeper',
+    tipName: 'Minesweeper',
+    description: '지뢰를 피해 모든 칸을 여세요. 우클릭으로 깃발을 표시합니다.',
+    hotkey: 'b',
+    render: () => <MinesweeperCanvas />,
+  },
+  {
+    id: 'picross',
+    title: '🖼️ Picross',
+    tipName: 'Picross',
+    description: '숫자 힌트를 이용해 그림을 완성하세요. 좌클릭=채우기, 우클릭=X 표시.',
+    hotkey: 'p',
+    render: () => <PicrossCanvas />,
+  },
+  {
+    id: 'match3',
+    title: '💎 Match-3',
+    tipName: 'Match-3',
+    description: '인접한 보석을 교환해 3개 이상 매치하면 제거되고 점수를 얻어요.',
+    hotkey: 'j',
+    render: () => <MatchThreeCanvas />,
+  },
+  {
+    id: 'frogger',
+    title: '🐸 Frogger',
+    tipName: 'Frogger',
+    description: '자동차를 피해 개구리를 위쪽 안전지대로 이동시키세요! 방향키로 조작합니다.',
+    hotkey: 'f',
+    render: () => <FroggerCanvas />,
+  },
+  {
+    id: 'tictactoe',
+    title: '⭕ Tic-Tac-Toe',
+    tipName: 'Tic-Tac-Toe',
+    description: 'X와 O를 번갈아 두며, 가로·세로·대각선으로 3개를 먼저 연결하면 승리! 클래식 틱택토 게임입니다.',
+    hotkey: 't',
+    render: () => <TicTacToeCanvas />,
+  },
+  {
+    id: 'whack',
+    title: '🐹 Whack-a-Mole',
+    tipName: 'Whack-a-Mole',
+    description: '두더지가 튀어나올 때 클릭해서 점수를 올려요! 30초 동안 최대한 많이 잡으세요.',
+    hotkey: 'w',
+    render: () => <WhackAMoleCanvas />,
+  },
+  {
+    id: 'space',
+    title: '👾 Space Invaders',
+    tipName: 'Space Invaders',
+    description: '우주선을 움직여 외계인 침략자들을 물리치세요! Spacebar로 발사하세요.',
+    hotkey: 'i',
+    render: () => <SpaceInvadersCanvas />,
+  },
+] as const;
+
+export type GameDefinition = typeof games[number];
+export type GameId = GameDefinition['id'];

--- a/src/theme/gameTheme.ts
+++ b/src/theme/gameTheme.ts
@@ -68,6 +68,11 @@ export const spacing = {
   xxl: 24
 };
 
+// 공통 레이아웃 설정
+export const layout = {
+  maxWidth: 640
+};
+
 export const gameContainerStyle: React.CSSProperties = {
   display: "grid",
   gap: spacing.lg,
@@ -84,7 +89,10 @@ export const canvasStyle: React.CSSProperties = {
   background: colors.canvasBackground,
   boxShadow: "0 10px 40px rgba(0,0,0,0.5), inset 0 0 0 1px rgba(255,255,255,0.06)",
   borderRadius: 14,
-  touchAction: "none"
+  touchAction: "none",
+  width: "100%",
+  height: "auto",
+  display: "block"
 };
 
 export const buttonStyles = {


### PR DESCRIPTION
## Summary
- block global hotkeys during Mastermind play so W/A/S/D and undo/reset keys don't switch games
- introduce Minesweeper canvas with reveal, flagging, and reset support, registered under hotkey `b`
- add Picross nonogram puzzle with generated hints, fill/mark controls, and R-key reset registered under hotkey `p`
- add Match-3 swapping puzzle with cascading clears and score tracking registered under hotkey `j`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6f5b11c8320a713106ebe51a06a