### PR TITLE
feat: add Galaga and improve input handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Ping Pong (React + TS)</title>
+    <title>Mini Games</title>
     <style>
       :root { color-scheme: dark; }
       html, body {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,94 +1,65 @@
-import React, { useEffect, useState } from "react";
-import GameMenu, { GameId } from "./components/GameMenu";
-import PingPongCanvas from "./PingPongCanvas";
-import TetrisCanvas from "./TetrisCanvas";
-import SnakeCanvas from "./SnakeCanvas";
-import OmokCanvas from "./OmokCanvas";
-import LightsOutCanvas from "./LightsOutCanvas";
-import SimonSaysCanvas from "./SimonSaysCanvas";
-import ReactionTestCanvas from "./ReactionTestCanvas";
-import AimTrainerCanvas from "./AimTrainerCanvas";
-import BreakoutCanvas from "./BreakoutCanvas";
-import FlappyBirdCanvas from "./FlappyBirdCanvas";
-import MemoryGameCanvas from "./MemoryGameCanvas";
-import DodgeGameCanvas from "./DodgeGameCanvas";
-import Game2048Canvas from "./Game2048Canvas";
-import SlidePuzzleCanvas from "./SlidePuzzleCanvas";
-import SokobanCanvas from "./SokobanCanvas";
-import ConnectFourCanvas from "./ConnectFourCanvas";
-import MiniGolfCanvas from "./MiniGolfCanvas";
-import TicTacToeCanvas from "./TicTacToeCanvas";
+import React, { useEffect, useState } from 'react';
+import GameMenu from './components/GameMenu';
+import { games, GameId } from './games';
+
+type GameView = GameId | 'menu';
 
 export default function App() {
-  const [game, setGame] = useState<GameId>("menu");
-
+  const [game, setGame] = useState<GameView>('menu');
+  // Reflect active game in the browser title
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "1") setGame("pingpong");
-      if (e.key === "2") setGame("tetris");
-      if (e.key === "3") setGame("snake");
-      if (e.key === "4") setGame("omok");
-      if (e.key === "5") setGame("lightsout");
-      if (e.key === "6") setGame("simon");
-      if (e.key === "7") setGame("reaction");
-      if (e.key === "8") setGame("aim");
-      if (e.key === "9") setGame("breakout");
-      if (e.key === "0") setGame("flappy");
-      if (e.key === "m") setGame("memory");
-      if (e.key === "d") setGame("dodge");
-      if (e.key === "-") setGame("2048");
-      if (e.key === "=") setGame("slide");
-      if (e.key === "s") setGame("sokoban");
-      if (e.key === "c") setGame("connect4");
-      if (e.key === "g") setGame("minigolf");
-      if (e.key === "t") setGame("tictactoe");
-      if (e.key === "Escape") setGame("menu");
+    const base = 'Mini Games';
+    if (game === 'menu') document.title = base;
+    else {
+      const current = games.find((g) => g.id === game);
+      document.title = current ? `${current.title} - ${base}` : base;
+    }
+  }, [game]);
+  // Allow exiting any game with Escape
+  useEffect(() => {
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setGame('menu');
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener('keydown', onEsc);
+    return () => window.removeEventListener('keydown', onEsc);
   }, []);
 
-  if (game === "menu") return <GameMenu onSelect={(id) => setGame(id)} />;
+  // Enable hotkeys only when the menu is active so game controls aren't blocked
+  useEffect(() => {
+    if (game !== 'menu') return;
 
-  switch (game) {
-    case "pingpong":
-      return <PingPongCanvas width={900} height={540} />;
-    case "tetris":
-      return <TetrisCanvas />;
-    case "snake":
-      return <SnakeCanvas />;
-    case "omok":
-      return <OmokCanvas />;
-    case "lightsout":
-      return <LightsOutCanvas />;
-    case "simon":
-      return <SimonSaysCanvas />;
-    case "reaction":
-      return <ReactionTestCanvas />;
-    case "aim":
-      return <AimTrainerCanvas />;
-    case "breakout":
-      return <BreakoutCanvas />;
-    case "flappy":
-      return <FlappyBirdCanvas />;
-    case "memory":
-      return <MemoryGameCanvas />;
-    case "dodge":
-      return <DodgeGameCanvas />;
-    case "2048":
-      return <Game2048Canvas />;
-    case "slide":
-      return <SlidePuzzleCanvas />;
-    case "sokoban":
-      return <SokobanCanvas />;
-    case "connect4":
-      return <ConnectFourCanvas />;
-    case "minigolf":
-      return <MiniGolfCanvas />;
-    case "tictactoe":
-      return <TicTacToeCanvas />;
-    default:
-      return null;
+    const hotkeyMap: Record<string, GameId> = {};
+    games.forEach((g) => {
+      hotkeyMap[g.hotkey.toLowerCase()] = g.id;
+    });
+
+    const onKey = (e: KeyboardEvent) => {
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey || e.repeat) return;
+      const target = e.target as HTMLElement | null;
+      if (
+        target &&
+        (target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
+          target.isContentEditable)
+      ) {
+        return;
+      }
+      const key = e.key.toLowerCase();
+      const id = hotkeyMap[key];
+      if (id) {
+        e.preventDefault();
+        setGame(id);
+      }
+    };
+
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [game]);
+
+  if (game === 'menu') {
+    return <GameMenu games={games} onSelect={(id) => setGame(id)} />;
   }
-}
 
+  const current = games.find((g) => g.id === game);
+  return current ? current.render() : null;
+}

--- a/src/BubbleShooterCanvas.tsx
+++ b/src/BubbleShooterCanvas.tsx
@@ -1,0 +1,328 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+
+const WIDTH = 480;
+const HEIGHT = 640;
+const RADIUS = 16;
+const COLS = 12;
+const ROWS = 20;
+const START_ROWS = 5;
+const COLORS = ['#ff595e', '#ffca3a', '#8ac926', '#1982c4', '#6a4c93'];
+
+interface Bubble {
+  x: number;
+  y: number;
+  dx: number;
+  dy: number;
+  color: number;
+  moving: boolean;
+}
+
+const BubbleShooterCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gridRef = useRef<number[][]>(
+    Array.from({ length: ROWS }, () => Array(COLS).fill(-1))
+  );
+  const bubbleRef = useRef<Bubble>({
+    x: WIDTH / 2,
+    y: HEIGHT - RADIUS - 10,
+    dx: 0,
+    dy: 0,
+    color: Math.floor(Math.random() * COLORS.length),
+    moving: false,
+  });
+  const angleRef = useRef(-Math.PI / 2);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'aim' | 'over'>('aim');
+
+  const reset = useCallback(() => {
+    gridRef.current = Array.from({ length: ROWS }, () => Array(COLS).fill(-1));
+    for (let r = 0; r < START_ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        gridRef.current[r][c] = Math.floor(Math.random() * COLORS.length);
+      }
+    }
+    bubbleRef.current = {
+      x: WIDTH / 2,
+      y: HEIGHT - RADIUS - 10,
+      dx: 0,
+      dy: 0,
+      color: Math.floor(Math.random() * COLORS.length),
+      moving: false,
+    };
+    angleRef.current = -Math.PI / 2;
+    setScore(0);
+    setState('aim');
+  }, []);
+
+  const neighbors = (r: number, c: number) => {
+    const dirs = r % 2 === 0
+      ? [
+          [-1, 0],
+          [-1, -1],
+          [0, -1],
+          [0, 1],
+          [1, 0],
+          [1, -1],
+        ]
+      : [
+          [-1, 0],
+          [-1, 1],
+          [0, -1],
+          [0, 1],
+          [1, 0],
+          [1, 1],
+        ];
+    return dirs
+      .map(([dr, dc]) => [r + dr, c + dc])
+      .filter(([nr, nc]) => nr >= 0 && nr < ROWS && nc >= 0 && nc < COLS);
+  };
+
+  const removeMatches = (r: number, c: number) => {
+    const color = gridRef.current[r][c];
+    const stack = [[r, c]];
+    const cells: [number, number][] = [];
+    const visited = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+    visited[r][c] = true;
+    while (stack.length) {
+      const [cr, cc] = stack.pop()!;
+      cells.push([cr, cc]);
+      for (const [nr, nc] of neighbors(cr, cc)) {
+        if (!visited[nr][nc] && gridRef.current[nr][nc] === color) {
+          visited[nr][nc] = true;
+          stack.push([nr, nc]);
+        }
+      }
+    }
+    if (cells.length >= 3) {
+      cells.forEach(([rr, cc]) => (gridRef.current[rr][cc] = -1));
+      setScore((s) => s + cells.length);
+      return true;
+    }
+    return false;
+  };
+
+  const removeFloating = () => {
+    const visited = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+    const stack: [number, number][] = [];
+    for (let c = 0; c < COLS; c++) {
+      if (gridRef.current[0][c] !== -1) {
+        visited[0][c] = true;
+        stack.push([0, c]);
+      }
+    }
+    while (stack.length) {
+      const [r, c] = stack.pop()!;
+      for (const [nr, nc] of neighbors(r, c)) {
+        if (!visited[nr][nc] && gridRef.current[nr][nc] !== -1) {
+          visited[nr][nc] = true;
+          stack.push([nr, nc]);
+        }
+      }
+    }
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (gridRef.current[r][c] !== -1 && !visited[r][c]) {
+          gridRef.current[r][c] = -1;
+          setScore((s) => s + 1);
+        }
+      }
+    }
+  };
+
+  const checkGameOver = () => {
+    const bottom = HEIGHT - 80;
+    for (let r = 0; r < ROWS; r++) {
+      for (let c = 0; c < COLS; c++) {
+        if (gridRef.current[r][c] !== -1) {
+          const y = r * RADIUS * 2 + RADIUS;
+          if (y >= bottom) {
+            setState('over');
+            return;
+          }
+        }
+      }
+    }
+  };
+
+  const shoot = () => {
+    if (bubbleRef.current.moving || state === 'over') return;
+    const speed = 6;
+    bubbleRef.current.dx = Math.cos(angleRef.current) * speed;
+    bubbleRef.current.dy = Math.sin(angleRef.current) * speed;
+    bubbleRef.current.moving = true;
+  };
+
+  useEffect(() => {
+    reset();
+  }, [reset]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const handleMove = (e: MouseEvent) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = e.clientX - rect.left;
+      const y = e.clientY - rect.top;
+      let angle = Math.atan2(y - (HEIGHT - RADIUS - 10), x - WIDTH / 2);
+      if (angle > -0.1) angle = -0.1;
+      if (angle < -Math.PI + 0.1) angle = -Math.PI + 0.1;
+      angleRef.current = angle;
+    };
+    const handleClick = (e: MouseEvent) => {
+      e.stopPropagation();
+      shoot();
+    };
+    canvas.addEventListener('mousemove', handleMove);
+    canvas.addEventListener('click', handleClick);
+    return () => {
+      canvas.removeEventListener('mousemove', handleMove);
+      canvas.removeEventListener('click', handleClick);
+    };
+  }, [state]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.stopPropagation();
+        reset();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [reset]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    let frame = 0;
+
+    const startX = (WIDTH - COLS * RADIUS * 2) / 2;
+
+    const draw = () => {
+      frame = requestAnimationFrame(draw);
+      ctx.clearRect(0, 0, WIDTH, HEIGHT);
+
+      // update moving bubble
+      const b = bubbleRef.current;
+      if (b.moving) {
+        const prevX = b.x;
+        const prevY = b.y;
+        b.x += b.dx;
+        b.y += b.dy;
+        if (b.x <= startX + RADIUS || b.x >= startX + COLS * RADIUS * 2 - RADIUS) {
+          b.dx *= -1;
+        }
+        if (b.y <= RADIUS) {
+          b.moving = false;
+        }
+        // check collision with existing bubbles
+        if (b.moving) {
+          outer: for (let r = 0; r < ROWS; r++) {
+            for (let c = 0; c < COLS; c++) {
+              const color = gridRef.current[r][c];
+              if (color === -1) continue;
+              const cx = startX + c * RADIUS * 2 + (r % 2 ? RADIUS : 0);
+              const cy = r * RADIUS * 2 + RADIUS;
+              const dx = b.x - cx;
+              const dy = b.y - cy;
+              if (dx * dx + dy * dy <= (RADIUS * 2 - 2) ** 2) {
+                b.moving = false;
+                break outer;
+              }
+            }
+          }
+        }
+        if (!b.moving) {
+          // revert to last valid position and snap to grid
+          b.x = prevX;
+          b.y = prevY;
+          const row = Math.round((b.y - RADIUS) / (RADIUS * 2));
+          const col = Math.round(
+            (b.x - startX - (row % 2 ? RADIUS : 0)) / (RADIUS * 2)
+          );
+          if (row < 0 || row >= ROWS || col < 0 || col >= COLS) {
+            setState('over');
+          } else {
+            gridRef.current[row][col] = b.color;
+            removeMatches(row, col);
+            removeFloating();
+            checkGameOver();
+            bubbleRef.current = {
+              x: WIDTH / 2,
+              y: HEIGHT - RADIUS - 10,
+              dx: 0,
+              dy: 0,
+              color: Math.floor(Math.random() * COLORS.length),
+              moving: false,
+            };
+          }
+        }
+      }
+
+      // draw grid
+      for (let r = 0; r < ROWS; r++) {
+        for (let c = 0; c < COLS; c++) {
+          const color = gridRef.current[r][c];
+          if (color === -1) continue;
+          const cx = startX + c * RADIUS * 2 + (r % 2 ? RADIUS : 0);
+          const cy = r * RADIUS * 2 + RADIUS;
+          ctx.beginPath();
+          ctx.arc(cx, cy, RADIUS - 1, 0, Math.PI * 2);
+          ctx.fillStyle = COLORS[color];
+          ctx.fill();
+        }
+      }
+
+      // draw shooter direction
+      ctx.beginPath();
+      ctx.moveTo(WIDTH / 2, HEIGHT - RADIUS - 10);
+      ctx.lineTo(
+        WIDTH / 2 + Math.cos(angleRef.current) * 40,
+        HEIGHT - RADIUS - 10 + Math.sin(angleRef.current) * 40
+      );
+      ctx.strokeStyle = '#ffffff';
+      ctx.stroke();
+
+      // draw current bubble
+      const drawX = b.moving ? b.x : WIDTH / 2;
+      const drawY = b.moving ? b.y : HEIGHT - RADIUS - 10;
+      ctx.beginPath();
+      ctx.arc(drawX, drawY, RADIUS - 1, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS[b.color];
+      ctx.fill();
+
+      if (state === 'over') {
+        ctx.fillStyle = '#ffffff';
+        ctx.font = '24px sans-serif';
+        ctx.fillText('Game Over', WIDTH / 2 - 60, HEIGHT / 2);
+      }
+    };
+
+    frame = requestAnimationFrame(draw);
+    return () => cancelAnimationFrame(frame);
+  }, [state]);
+
+  const topInfo = (
+    <div style={{ textAlign: 'center', color: '#bcbcbe' }}>점수: {score}</div>
+  );
+
+  const instructions = '마우스로 조준하고 클릭하여 버블을 발사하세요. R로 리셋.';
+
+  return (
+    <GameLayout title="Bubble Shooter" topInfo={topInfo} bottomInfo={instructions}>
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Bubble Shooter"
+        width={WIDTH}
+        height={HEIGHT}
+      />
+    </GameLayout>
+  );
+};
+
+export default BubbleShooterCanvas;
+

--- a/src/ColumnsCanvas.tsx
+++ b/src/ColumnsCanvas.tsx
@@ -1,0 +1,246 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const COLS = 6;
+const ROWS = 13;
+const CELL = 30;
+const COLORS = ['#ff595e', '#1982c4', '#8ac926'];
+
+interface Piece {
+  x: number;
+  y: number; // top cell row
+  colors: [number, number, number];
+}
+
+const randColor = () => Math.floor(Math.random() * COLORS.length);
+
+const ColumnsCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gridRef = useRef<number[][]>(
+    Array.from({ length: ROWS }, () => Array(COLS).fill(-1))
+  );
+  const pieceRef = useRef<Piece | null>(null);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'playing' | 'over'>('playing');
+
+  const canMove = (dx: number, dy: number) => {
+    const p = pieceRef.current;
+    if (!p) return false;
+    const nx = p.x + dx;
+    for (let i = 0; i < 3; i++) {
+      const ny = p.y + dy + i;
+      if (nx < 0 || nx >= COLS || ny >= ROWS) return false;
+      if (ny >= 0 && gridRef.current[ny][nx] !== -1) return false;
+    }
+    return true;
+  };
+
+  const spawnPiece = useCallback(() => {
+    pieceRef.current = {
+      x: Math.floor(COLS / 2),
+      y: -3,
+      colors: [randColor(), randColor(), randColor()],
+    };
+    if (!canMove(0, 0)) setState('over');
+  }, []);
+
+  const applyGravity = () => {
+    for (let x = 0; x < COLS; x++) {
+      let write = ROWS - 1;
+      for (let y = ROWS - 1; y >= 0; y--) {
+        const color = gridRef.current[y][x];
+        if (color !== -1) {
+          gridRef.current[write][x] = color;
+          if (write !== y) gridRef.current[y][x] = -1;
+          write--;
+        }
+      }
+      for (let y = write; y >= 0; y--) gridRef.current[y][x] = -1;
+    }
+  };
+
+  const clearMatches = () => {
+    let removedTotal = 0;
+    while (true) {
+      const toClear = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+      let found = 0;
+      const dirs = [
+        [1, 0],
+        [0, 1],
+        [1, 1],
+        [1, -1],
+      ];
+      for (let y = 0; y < ROWS; y++) {
+        for (let x = 0; x < COLS; x++) {
+          const color = gridRef.current[y][x];
+          if (color === -1) continue;
+          for (const [dx, dy] of dirs) {
+            const cells: [number, number][] = [[x, y]];
+            let nx = x + dx;
+            let ny = y + dy;
+            while (
+              nx >= 0 &&
+              nx < COLS &&
+              ny >= 0 &&
+              ny < ROWS &&
+              gridRef.current[ny][nx] === color
+            ) {
+              cells.push([nx, ny]);
+              nx += dx;
+              ny += dy;
+            }
+            nx = x - dx;
+            ny = y - dy;
+            while (
+              nx >= 0 &&
+              nx < COLS &&
+              ny >= 0 &&
+              ny < ROWS &&
+              gridRef.current[ny][nx] === color
+            ) {
+              cells.push([nx, ny]);
+              nx -= dx;
+              ny -= dy;
+            }
+            if (cells.length >= 3) {
+              cells.forEach(([cx, cy]) => (toClear[cy][cx] = true));
+            }
+          }
+        }
+      }
+      for (let y = 0; y < ROWS; y++) {
+        for (let x = 0; x < COLS; x++) {
+          if (toClear[y][x]) {
+            gridRef.current[y][x] = -1;
+            found++;
+          }
+        }
+      }
+      if (!found) break;
+      removedTotal += found;
+      applyGravity();
+    }
+    if (removedTotal) setScore((s) => s + removedTotal);
+  };
+
+  const lockPiece = () => {
+    const p = pieceRef.current!;
+    for (let i = 0; i < 3; i++) {
+      const y = p.y + i;
+      if (y < 0) {
+        setState('over');
+        return;
+      }
+      gridRef.current[y][p.x] = p.colors[i];
+    }
+    pieceRef.current = null;
+    clearMatches();
+  };
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        const color = gridRef.current[y][x];
+        if (color !== -1) {
+          ctx.fillStyle = COLORS[color];
+          ctx.fillRect(x * CELL, y * CELL, CELL, CELL);
+        }
+        ctx.strokeStyle = '#333';
+        ctx.strokeRect(x * CELL, y * CELL, CELL, CELL);
+      }
+    }
+    const p = pieceRef.current;
+    if (p) {
+      for (let i = 0; i < 3; i++) {
+        const y = p.y + i;
+        if (y >= 0) {
+          ctx.fillStyle = COLORS[p.colors[i]];
+          ctx.fillRect(p.x * CELL, y * CELL, CELL, CELL);
+          ctx.strokeStyle = '#333';
+          ctx.strokeRect(p.x * CELL, y * CELL, CELL, CELL);
+        }
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = COLS * CELL;
+    canvas.height = ROWS * CELL;
+    draw();
+    const interval = setInterval(() => {
+      if (state !== 'playing') return;
+      if (!pieceRef.current) spawnPiece();
+      else if (canMove(0, 1)) pieceRef.current.y++;
+      else lockPiece();
+      draw();
+    }, 500);
+    return () => clearInterval(interval);
+  }, [draw, spawnPiece, state]);
+
+  const resetGame = useCallback(() => {
+    gridRef.current = Array.from({ length: ROWS }, () => Array(COLS).fill(-1));
+    pieceRef.current = null;
+    setScore(0);
+    setState('playing');
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['arrowleft', 'arrowright', 'arrowdown', 'arrowup'].includes(key)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (['a', 'd', 's', 'w', 'r', ' '].includes(key)) e.stopPropagation();
+      if (key === 'r') {
+        resetGame();
+        return;
+      }
+      if (state !== 'playing' || !pieceRef.current) return;
+      if (key === 'a' && canMove(-1, 0)) pieceRef.current.x--;
+      else if (key === 'd' && canMove(1, 0)) pieceRef.current.x++;
+      else if (key === 's' && canMove(0, 1)) pieceRef.current.y++;
+      else if (key === ' ') {
+        while (canMove(0, 1)) pieceRef.current.y++;
+        lockPiece();
+      } else if (key === 'w') {
+        const colors = pieceRef.current.colors;
+        colors.unshift(colors.pop()!);
+      }
+      draw();
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [draw, resetGame, state, lockPiece]);
+
+  return (
+    <GameLayout
+      title="🔶 Columns"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>A/D 좌우, S 아래, W 색순환, Space 즉시드랍, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Columns"
+        width={COLS * CELL}
+        height={ROWS * CELL}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default ColumnsCanvas;
+

--- a/src/ConnectFourCanvas.tsx
+++ b/src/ConnectFourCanvas.tsx
@@ -29,7 +29,8 @@ const CANVAS_WIDTH = 700;
 const CANVAS_HEIGHT = 600;
 const CELL_SIZE = 80;
 const CHIP_RADIUS = 30;
-const MARGIN = 50;
+const MARGIN_X = (CANVAS_WIDTH - COLS * CELL_SIZE) / 2;
+const MARGIN_Y = (CANVAS_HEIGHT - ROWS * CELL_SIZE) / 2;
 
 // 칩 색상
 const CHIP_COLORS = {
@@ -279,7 +280,7 @@ const ConnectFourCanvas: React.FC = () => {
 
     const rect = canvas.getBoundingClientRect();
     const x = event.clientX - rect.left;
-    const col = Math.floor((x - MARGIN) / CELL_SIZE);
+    const col = Math.floor((x - MARGIN_X) / CELL_SIZE);
 
     if (col >= 0 && col < COLS) {
       makeMove(col);
@@ -298,7 +299,7 @@ const ConnectFourCanvas: React.FC = () => {
 
     const rect = canvas.getBoundingClientRect();
     const x = event.clientX - rect.left;
-    const col = Math.floor((x - MARGIN) / CELL_SIZE);
+    const col = Math.floor((x - MARGIN_X) / CELL_SIZE);
 
     if (col >= 0 && col < COLS && isValidMove(board, col)) {
       setHoveredCol(col);
@@ -322,8 +323,8 @@ const ConnectFourCanvas: React.FC = () => {
     // 그리드 그리기
     for (let row = 0; row < ROWS; row++) {
       for (let col = 0; col < COLS; col++) {
-        const x = MARGIN + col * CELL_SIZE;
-        const y = MARGIN + row * CELL_SIZE;
+        const x = MARGIN_X + col * CELL_SIZE;
+        const y = MARGIN_Y + row * CELL_SIZE;
         const centerX = x + CELL_SIZE / 2;
         const centerY = y + CELL_SIZE / 2;
 
@@ -368,17 +369,17 @@ const ConnectFourCanvas: React.FC = () => {
 
     // 호버된 열 하이라이트
     if (hoveredCol !== null && gameState === GameState.PLAYING) {
-      const x = MARGIN + hoveredCol * CELL_SIZE;
+      const x = MARGIN_X + hoveredCol * CELL_SIZE;
       ctx.fillStyle = 'rgba(255, 255, 255, 0.3)';
-      ctx.fillRect(x, MARGIN, CELL_SIZE, ROWS * CELL_SIZE);
+      ctx.fillRect(x, MARGIN_Y, CELL_SIZE, ROWS * CELL_SIZE);
     }
 
     // 드랍 애니메이션
     if (droppingChip) {
       const { col, row, progress } = droppingChip;
-      const x = MARGIN + col * CELL_SIZE + CELL_SIZE / 2;
-      const startY = MARGIN - CHIP_RADIUS;
-      const endY = MARGIN + row * CELL_SIZE + CELL_SIZE / 2;
+      const x = MARGIN_X + col * CELL_SIZE + CELL_SIZE / 2;
+      const startY = MARGIN_Y - CHIP_RADIUS;
+      const endY = MARGIN_Y + row * CELL_SIZE + CELL_SIZE / 2;
       const currentY = startY + (endY - startY) * progress;
 
       ctx.fillStyle = CHIP_COLORS[currentPlayer];

--- a/src/DominoCanvas.tsx
+++ b/src/DominoCanvas.tsx
@@ -1,0 +1,127 @@
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import { layout } from './theme/gameTheme';
+
+const WIDTH = layout.maxWidth;
+const HEIGHT = 400;
+const DOMINO_WIDTH = 20;
+const DOMINO_HEIGHT = 80;
+const SPACING = 10;
+const NUM = 20;
+
+interface Domino {
+  x: number;
+  y: number;
+  angle: number; // radians
+  falling: boolean;
+  fallen: boolean;
+}
+
+const DominoCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const dominosRef = useRef<Domino[]>([]);
+  const animRef = useRef<number>();
+  const [score, setScore] = useState(0);
+
+  const reset = useCallback(() => {
+    const startX = (WIDTH - (NUM * DOMINO_WIDTH + (NUM - 1) * SPACING)) / 2;
+    dominosRef.current = Array.from({ length: NUM }, (_, i) => ({
+      x: startX + i * (DOMINO_WIDTH + SPACING),
+      y: HEIGHT - DOMINO_HEIGHT,
+      angle: 0,
+      falling: false,
+      fallen: false,
+    }));
+    setScore(0);
+  }, []);
+
+  const start = () => {
+    const dominos = dominosRef.current;
+    if (!dominos[0].falling && !dominos[0].fallen) dominos[0].falling = true;
+  };
+
+  useEffect(() => { reset(); }, [reset]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        start();
+      }
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        reset();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [reset]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const update = () => {
+      const dominos = dominosRef.current;
+      dominos.forEach((d, i) => {
+        if (d.falling && !d.fallen){
+          d.angle += 0.05;
+          if (d.angle >= Math.PI / 2){
+            d.angle = Math.PI / 2;
+            d.falling = false;
+            d.fallen = true;
+            setScore(s => s + 1);
+            if (i + 1 < dominos.length){
+              dominos[i+1].falling = true;
+            }
+          }
+        }
+      });
+    };
+
+    const draw = () => {
+      animRef.current = requestAnimationFrame(draw);
+      update();
+      ctx.clearRect(0,0,WIDTH,HEIGHT);
+      ctx.fillStyle = '#222';
+      ctx.fillRect(0,HEIGHT-20,WIDTH,20);
+      dominosRef.current.forEach(d => {
+        ctx.save();
+        ctx.translate(d.x + DOMINO_WIDTH/2, d.y + DOMINO_HEIGHT);
+        ctx.rotate(-d.angle);
+        ctx.fillStyle = '#f2f2f2';
+        ctx.fillRect(-DOMINO_WIDTH/2, -DOMINO_HEIGHT, DOMINO_WIDTH, DOMINO_HEIGHT);
+        ctx.restore();
+      });
+    };
+    draw();
+    return () => cancelAnimationFrame(animRef.current!);
+  }, []);
+
+  const topInfo = <div style={{textAlign:'center', color:'#bcbcbe'}}>쓰러뜨린 수: {score}</div>;
+  const instructions = '클릭 또는 스페이스바로 처음 도미노를 쓰러뜨리세요. R로 리셋.';
+
+  const handleClick = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation();
+    start();
+  }, []);
+
+  return (
+    <GameLayout title="Domino Topple" topInfo={topInfo} bottomInfo={instructions}>
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Domino Topple"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+      />
+    </GameLayout>
+  );
+};
+
+export default DominoCanvas;

--- a/src/FroggerCanvas.tsx
+++ b/src/FroggerCanvas.tsx
@@ -1,0 +1,192 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const FROG_SIZE = 40;
+const SAFE_ZONE = 60;
+const LANE_HEIGHT = 60;
+const LANE_GAP = 20;
+const LANES = 3;
+
+interface Car {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  speed: number;
+}
+
+const FroggerCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const carsRef = useRef<Car[]>([]);
+  const frogRef = useRef({ x: 0, y: 0 });
+
+  const [score, setScore] = useState(0);
+  const [lives, setLives] = useState(3);
+  const [gameState, setGameState] = useState<'playing' | 'gameover'>('playing');
+
+  const initCars = useCallback(() => {
+    const cars: Car[] = [];
+    const speeds = [120, -150, 100];
+    for (let i = 0; i < LANES; i++) {
+      const y = CANVAS_HEIGHT - SAFE_ZONE - (i + 1) * (LANE_HEIGHT + LANE_GAP) + (LANE_HEIGHT - 40) / 2;
+      for (let j = 0; j < 3; j++) {
+        cars.push({
+          x: j * (CANVAS_WIDTH / 3),
+          y,
+          width: 80,
+          height: 40,
+          speed: speeds[i]
+        });
+      }
+    }
+    carsRef.current = cars;
+  }, []);
+
+  const resetFrog = useCallback(() => {
+    frogRef.current = {
+      x: CANVAS_WIDTH / 2 - FROG_SIZE / 2,
+      y: CANVAS_HEIGHT - SAFE_ZONE + (SAFE_ZONE - FROG_SIZE) / 2
+    };
+  }, []);
+
+  const startGame = useCallback(() => {
+    setScore(0);
+    setLives(3);
+    setGameState('playing');
+    initCars();
+    resetFrog();
+  }, [initCars, resetFrog]);
+
+  const handleKey = useCallback((e: KeyboardEvent) => {
+    if (gameState !== 'playing') return;
+    const frog = frogRef.current;
+    switch (e.key) {
+      case 'ArrowUp':
+      case 'w':
+      case 'W':
+        frog.y = Math.max(0, frog.y - FROG_SIZE);
+        break;
+      case 'ArrowDown':
+      case 's':
+      case 'S':
+        frog.y = Math.min(CANVAS_HEIGHT - FROG_SIZE, frog.y + FROG_SIZE);
+        break;
+      case 'ArrowLeft':
+      case 'a':
+      case 'A':
+        frog.x = Math.max(0, frog.x - FROG_SIZE);
+        break;
+      case 'ArrowRight':
+      case 'd':
+      case 'D':
+        frog.x = Math.min(CANVAS_WIDTH - FROG_SIZE, frog.x + FROG_SIZE);
+        break;
+    }
+    if (frog.y <= 0) {
+      setScore(s => s + 1);
+      resetFrog();
+    }
+  }, [gameState, resetFrog]);
+
+  const update = useCallback((dt: number) => {
+    if (gameState !== 'playing') return;
+    const frog = frogRef.current;
+    carsRef.current.forEach(car => {
+      car.x += car.speed * dt;
+      if (car.speed > 0 && car.x > CANVAS_WIDTH + car.width) car.x = -car.width;
+      if (car.speed < 0 && car.x < -car.width) car.x = CANVAS_WIDTH + car.width;
+      if (
+        frog.x < car.x + car.width &&
+        frog.x + FROG_SIZE > car.x &&
+        frog.y < car.y + car.height &&
+        frog.y + FROG_SIZE > car.y
+      ) {
+        setLives(l => {
+          const nl = l - 1;
+          if (nl <= 0) setGameState('gameover');
+          return nl;
+        });
+        resetFrog();
+      }
+    });
+  }, [gameState, resetFrog]);
+
+  const draw = useCallback(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // background
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // safe zones
+    ctx.fillStyle = '#3b5';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, SAFE_ZONE);
+    ctx.fillRect(0, CANVAS_HEIGHT - SAFE_ZONE, CANVAS_WIDTH, SAFE_ZONE);
+
+    // lanes
+    ctx.fillStyle = '#555';
+    for (let i = 0; i < LANES; i++) {
+      const y = CANVAS_HEIGHT - SAFE_ZONE - (i + 1) * (LANE_HEIGHT + LANE_GAP);
+      ctx.fillRect(0, y, CANVAS_WIDTH, LANE_HEIGHT);
+    }
+
+    // cars
+    ctx.fillStyle = 'orange';
+    carsRef.current.forEach(car => {
+      ctx.fillRect(car.x, car.y, car.width, car.height);
+    });
+
+    // frog
+    ctx.fillStyle = 'lime';
+    const frog = frogRef.current;
+    ctx.fillRect(frog.x, frog.y, FROG_SIZE, FROG_SIZE);
+  }, []);
+
+  const loop = useCallback((time: number) => {
+    const prev = (loop as any).prev || time;
+    const dt = (time - prev) / 1000;
+    (loop as any).prev = time;
+    update(dt);
+    draw();
+    animationRef.current = requestAnimationFrame(loop);
+  }, [draw, update]);
+
+  useEffect(() => {
+    startGame();
+    const handler = (e: KeyboardEvent) => handleKey(e);
+    window.addEventListener('keydown', handler);
+    animationRef.current = requestAnimationFrame(loop);
+    return () => {
+      window.removeEventListener('keydown', handler);
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [handleKey, loop, startGame]);
+
+  return (
+    <GameManager
+      title="Frogger"
+      gameIcon="🐸"
+      gameStats={<div>Score: {score} | Lives: {lives}</div>}
+      gameStatus={gameState === 'gameover' ? 'Game Over' : undefined}
+      actionButtons={<GameButton onClick={startGame}>Reset</GameButton>}
+      instructions={<div>방향키로 이동하여 위쪽으로 건너가세요</div>}
+    >
+      <GameCanvas
+        gameTitle="frogger"
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+      />
+    </GameManager>
+  );
+};
+
+export default FroggerCanvas;

--- a/src/GalagaCanvas.tsx
+++ b/src/GalagaCanvas.tsx
@@ -1,0 +1,216 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const PLAYER_SPEED = 300;
+const BULLET_SPEED = 500;
+const FIRE_DELAY = 300; // ms
+const ENEMY_SPEED = 40;
+
+interface Bullet {
+  x: number;
+  y: number;
+}
+
+interface Enemy {
+  baseX: number;
+  x: number;
+  y: number;
+  t: number;
+  alive: boolean;
+}
+
+const GalagaCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const lastTimeRef = useRef(0);
+  const keysRef = useRef<Set<string>>(new Set());
+  const bulletsRef = useRef<Bullet[]>([]);
+  const enemiesRef = useRef<Enemy[]>([]);
+  const playerXRef = useRef(CANVAS_WIDTH / 2);
+  const lastShotRef = useRef(0);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'playing' | 'won' | 'gameover'>('playing');
+
+  const initEnemies = useCallback(() => {
+    const enemies: Enemy[] = [];
+    for (let i = 0; i < 15; i++) {
+      const row = Math.floor(i / 5);
+      const col = i % 5;
+      const baseX = 80 + col * 80;
+      enemies.push({ baseX, x: baseX, y: 40 + row * 60, t: Math.random() * Math.PI * 2, alive: true });
+    }
+    enemiesRef.current = enemies;
+  }, []);
+
+  const start = useCallback(() => {
+    setScore(0);
+    setState('playing');
+    bulletsRef.current = [];
+    playerXRef.current = CANVAS_WIDTH / 2;
+    lastShotRef.current = 0;
+    initEnemies();
+  }, [initEnemies]);
+
+  const update = useCallback(
+    (dt: number) => {
+      if (state !== 'playing') return;
+
+      if (keysRef.current.has('ArrowLeft') || keysRef.current.has('KeyA')) {
+        playerXRef.current = Math.max(20, playerXRef.current - PLAYER_SPEED * dt);
+      }
+      if (keysRef.current.has('ArrowRight') || keysRef.current.has('KeyD')) {
+        playerXRef.current = Math.min(CANVAS_WIDTH - 20, playerXRef.current + PLAYER_SPEED * dt);
+      }
+
+      bulletsRef.current = bulletsRef.current.filter((b) => {
+        b.y -= BULLET_SPEED * dt;
+        return b.y > -10;
+      });
+
+      enemiesRef.current.forEach((e) => {
+        if (!e.alive) return;
+        e.t += dt;
+        e.x = e.baseX + Math.sin(e.t * 2) * 40;
+        e.y += ENEMY_SPEED * dt;
+      });
+
+      bulletsRef.current.forEach((b) => {
+        enemiesRef.current.forEach((e) => {
+          if (
+            e.alive &&
+            Math.abs(b.x - e.x) < 20 &&
+            Math.abs(b.y - e.y) < 20
+          ) {
+            e.alive = false;
+            b.y = -20;
+            setScore((s) => s + 10);
+          }
+        });
+      });
+
+      if (enemiesRef.current.every((e) => !e.alive)) setState('won');
+      if (enemiesRef.current.some((e) => e.alive && e.y > CANVAS_HEIGHT - 60)) setState('gameover');
+    },
+    [state]
+  );
+
+  const draw = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+      ctx.fillStyle = '#0f0';
+      ctx.fillRect(playerXRef.current - 20, CANVAS_HEIGHT - 40, 40, 20);
+
+      ctx.fillStyle = '#ff0';
+      bulletsRef.current.forEach((b) => ctx.fillRect(b.x - 2, b.y - 10, 4, 10));
+
+      ctx.fillStyle = '#f00';
+      enemiesRef.current.forEach((e) => {
+        if (e.alive) ctx.fillRect(e.x - 20, e.y - 20, 40, 20);
+      });
+
+      ctx.fillStyle = '#fff';
+      ctx.font = '20px Arial';
+      ctx.fillText(`Score: ${score}`, 20, 30);
+
+      if (state !== 'playing') {
+        ctx.fillStyle = 'rgba(0,0,0,0.6)';
+        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        ctx.textAlign = 'center';
+        ctx.fillStyle = state === 'won' ? '#0f0' : '#f00';
+        ctx.font = '48px Arial';
+        ctx.fillText(state === 'won' ? 'YOU WIN!' : 'GAME OVER', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+        ctx.fillStyle = '#fff';
+        ctx.font = '24px Arial';
+        ctx.fillText('Press R to Restart', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 40);
+        ctx.textAlign = 'left';
+      }
+    },
+    [score, state]
+  );
+
+  const loop = useCallback(
+    (time: number) => {
+      if (!lastTimeRef.current) lastTimeRef.current = time;
+      const dt = (time - lastTimeRef.current) / 1000;
+      lastTimeRef.current = time;
+      update(dt);
+      const ctx = canvasRef.current?.getContext('2d');
+      if (ctx) draw(ctx);
+      animationRef.current = requestAnimationFrame(loop);
+    },
+    [update, draw]
+  );
+
+  useEffect(() => {
+    start();
+  }, [start]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (['ArrowLeft', 'ArrowRight', 'KeyA', 'KeyD', 'Space', 'KeyR'].includes(e.code)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      keysRef.current.add(e.code);
+      if (e.code === 'Space' && state === 'playing') {
+        const now = performance.now();
+        if (now - lastShotRef.current > FIRE_DELAY) {
+          bulletsRef.current.push({ x: playerXRef.current, y: CANVAS_HEIGHT - 40 });
+          lastShotRef.current = now;
+        }
+      }
+      if (e.code === 'KeyR' && state !== 'playing') start();
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(e.code);
+    };
+    window.addEventListener('keydown', onKeyDown, { capture: true });
+    window.addEventListener('keyup', onKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, { capture: true });
+      window.removeEventListener('keyup', onKeyUp, { capture: true });
+    };
+  }, [state, start]);
+
+  useEffect(() => {
+    animationRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [loop]);
+
+  const gameStats = <div>점수: {score}</div>;
+  const instructions = 'A/D 또는 ←/→ 이동, Space 발사, R 재시작';
+  const actionButtons = (
+    <GameButton onClick={start} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  return (
+    <GameManager
+      title="Galaga"
+      gameIcon="🚀"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        gameTitle="Galaga"
+      />
+    </GameManager>
+  );
+};
+
+export default GalagaCanvas;
+

--- a/src/HextrisCanvas.tsx
+++ b/src/HextrisCanvas.tsx
@@ -1,0 +1,170 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const COLORS = ['#ff595e', '#1982c4', '#6a4c93', '#8ac926', '#ffca3a', '#ff924c'];
+const WIDTH = 300;
+const HEIGHT = 600;
+const RADIUS = 80;
+const BLOCK = 20;
+// pull the hexagon closer to the bottom edge for a longer drop
+const BOTTOM_MARGIN = 20;
+const CENTER_Y = HEIGHT - RADIUS - BOTTOM_MARGIN;
+const START_Y = -CENTER_Y - BLOCK;
+
+interface FallingBlock {
+  color: number;
+  y: number; // relative to center, negative going up
+}
+
+const HextrisCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const rotationRef = useRef(0);
+  const stacksRef = useRef<number[]>(Array(6).fill(0));
+  const blockRef = useRef<FallingBlock | null>(null);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'playing' | 'over'>('playing');
+
+  const resetGame = useCallback(() => {
+    rotationRef.current = 0;
+    stacksRef.current = Array(6).fill(0);
+    blockRef.current = null;
+    setScore(0);
+    setState('playing');
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.scale(dpr, dpr);
+
+    let prev: number | null = null;
+    let rafId: number;
+    const loop = (time: number) => {
+      if (prev === null) prev = time;
+      const delta = time - prev;
+      prev = time;
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, WIDTH, HEIGHT);
+      ctx.fillStyle = '#222';
+      ctx.fillRect(0, 0, WIDTH, HEIGHT);
+      ctx.save();
+      ctx.translate(WIDTH / 2, CENTER_Y);
+      // rotate hexagon -30 degrees so a face, not an edge, points upward
+      ctx.rotate(rotationRef.current * (Math.PI / 3) - Math.PI / 6);
+      // draw hexagon wedges
+      for (let i = 0; i < 6; i++) {
+        const a1 = (i * Math.PI) / 3 - Math.PI / 2;
+        const a2 = ((i + 1) * Math.PI) / 3 - Math.PI / 2;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(RADIUS * Math.cos(a1), RADIUS * Math.sin(a1));
+        ctx.lineTo(RADIUS * Math.cos(a2), RADIUS * Math.sin(a2));
+        ctx.closePath();
+        ctx.fillStyle = COLORS[i];
+        ctx.fill();
+        // draw stack
+        const angleMid = (a1 + a2) / 2;
+        for (let h = 0; h < stacksRef.current[i]; h++) {
+          const dist = RADIUS + BLOCK * (h + 0.5);
+          const bx = dist * Math.cos(angleMid) - BLOCK / 2;
+          const by = dist * Math.sin(angleMid) - BLOCK / 2;
+          ctx.fillStyle = COLORS[i];
+          ctx.fillRect(bx, by, BLOCK, BLOCK);
+        }
+      }
+      ctx.restore();
+
+      // draw falling block
+      if (state === 'playing') {
+        if (!blockRef.current) {
+          blockRef.current = { color: Math.floor(Math.random() * 6), y: START_Y };
+        }
+        const b = blockRef.current!;
+        b.y += (delta / 16) * 4; // speed
+        ctx.save();
+        ctx.translate(WIDTH / 2, CENTER_Y);
+        ctx.fillStyle = COLORS[b.color];
+        ctx.fillRect(-BLOCK / 2, b.y - BLOCK, BLOCK, BLOCK);
+        ctx.restore();
+        if (b.y >= -RADIUS) {
+          const topIndex = ((-rotationRef.current % 6) + 6) % 6;
+          if (b.color !== topIndex) {
+            setState('over');
+          } else {
+            stacksRef.current[topIndex]++;
+            if (stacksRef.current[topIndex] >= 3) {
+              setScore(s => s + stacksRef.current[topIndex]);
+              stacksRef.current[topIndex] = 0;
+            }
+          }
+          blockRef.current = null;
+        }
+      } else {
+        ctx.fillStyle = '#fff';
+        ctx.font = '24px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('Game Over', WIDTH / 2, HEIGHT / 2);
+      }
+
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, [state]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['a', 'd', 'w', 's', 'r'].includes(key)) {
+        e.stopPropagation();
+      }
+      if (key === 'a' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        rotationRef.current = (rotationRef.current + 5) % 6;
+      } else if (key === 'd' || e.key === 'ArrowRight') {
+        e.preventDefault();
+        rotationRef.current = (rotationRef.current + 1) % 6;
+      } else if (key === 'w') {
+        e.preventDefault();
+        rotationRef.current = (rotationRef.current + 3) % 6;
+      } else if (key === 's') {
+        e.preventDefault();
+        rotationRef.current = (rotationRef.current + 3) % 6;
+      } else if (key === 'r') {
+        e.preventDefault();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="🔷 Hextris"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>좌우 키(A/D)로 회전, W/S로 뒤집기. R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Hextris"
+        width={WIDTH}
+        height={HEIGHT}
+        style={{ aspectRatio: `${WIDTH} / ${HEIGHT}` }}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default HextrisCanvas;
+

--- a/src/MastermindCanvas.tsx
+++ b/src/MastermindCanvas.tsx
@@ -1,0 +1,277 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const ROWS = 10;
+const PEGS = 4;
+const COLORS = ['#e74c3c', '#3498db', '#27ae60', '#f1c40f', '#e91e63', '#8e44ad'];
+const COLOR_NAMES = ['빨강', '파랑', '초록', '노랑', '분홍', '보라'];
+const CANVAS_WIDTH = 360;
+const CANVAS_HEIGHT = 640;
+const TOP_MARGIN = 40;
+const ROW_SPACING = 40;
+const PEG_RADIUS = 12;
+const PEG_SPACING = 40;
+const FEEDBACK_RADIUS = 6;
+const FEEDBACK_SPACING = 16;
+const PALETTE_RADIUS = 15;
+const PALETTE_SPACING = 40;
+
+function generateSecret() {
+  return Array.from({ length: PEGS }, () => Math.floor(Math.random() * COLORS.length));
+}
+
+const MastermindCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [secret, setSecret] = useState<number[]>(() => generateSecret());
+  const [guesses, setGuesses] = useState<number[][]>(
+    Array.from({ length: ROWS }, () => Array(PEGS).fill(-1))
+  );
+  const [results, setResults] = useState<{ correct: number; misplaced: number }[]>([]);
+  const [currentRow, setCurrentRow] = useState(0);
+  const [gameState, setGameState] = useState<'playing' | 'won' | 'lost'>('playing');
+
+  const resetGame = useCallback(() => {
+    setSecret(generateSecret());
+    setGuesses(Array.from({ length: ROWS }, () => Array(PEGS).fill(-1)));
+    setResults([]);
+    setCurrentRow(0);
+    setGameState('playing');
+  }, []);
+
+  const handleUndo = useCallback(() => {
+    if (gameState !== 'playing') return;
+    const row = guesses[currentRow];
+    let idx = -1;
+    for (let i = PEGS - 1; i >= 0; i--) {
+      if (row[i] !== -1) {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) return;
+    const newGuesses = guesses.map((r, ri) =>
+      ri === currentRow ? r.map((v, ci) => (ci === idx ? -1 : v)) : r
+    );
+    setGuesses(newGuesses);
+  }, [gameState, guesses, currentRow]);
+
+  const submitGuess = useCallback(() => {
+    if (gameState !== 'playing') return;
+    if (guesses[currentRow].some(v => v === -1)) return;
+    const guess = guesses[currentRow];
+
+    const secretUsed = Array(PEGS).fill(false);
+    const guessUsed = Array(PEGS).fill(false);
+    let correct = 0;
+    let misplaced = 0;
+
+    for (let i = 0; i < PEGS; i++) {
+      if (guess[i] === secret[i]) {
+        correct++;
+        secretUsed[i] = true;
+        guessUsed[i] = true;
+      }
+    }
+    for (let i = 0; i < PEGS; i++) {
+      if (guessUsed[i]) continue;
+      for (let j = 0; j < PEGS; j++) {
+        if (!secretUsed[j] && guess[i] === secret[j]) {
+          misplaced++;
+          secretUsed[j] = true;
+          break;
+        }
+      }
+    }
+
+    const newResults = [...results];
+    newResults[currentRow] = { correct, misplaced };
+    setResults(newResults);
+
+    if (correct === PEGS) {
+      setGameState('won');
+    } else if (currentRow === ROWS - 1) {
+      setGameState('lost');
+    } else {
+      setCurrentRow(currentRow + 1);
+    }
+  }, [gameState, guesses, currentRow, secret, results]);
+
+  const handleCanvasClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
+    if (gameState !== 'playing') return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const rect = canvas.getBoundingClientRect();
+    const scaleX = CANVAS_WIDTH / rect.width;
+    const scaleY = CANVAS_HEIGHT / rect.height;
+    const x = (e.clientX - rect.left) * scaleX;
+    const y = (e.clientY - rect.top) * scaleY;
+
+    const paletteY = TOP_MARGIN + ROW_SPACING * ROWS + 60;
+    const paletteStartX = (CANVAS_WIDTH - (COLORS.length - 1) * PALETTE_SPACING) / 2;
+    for (let i = 0; i < COLORS.length; i++) {
+      const cx = paletteStartX + i * PALETTE_SPACING;
+      const cy = paletteY;
+      const dist = Math.hypot(x - cx, y - cy);
+      if (dist <= PALETTE_RADIUS) {
+        const colIndex = guesses[currentRow].findIndex(v => v === -1);
+        if (colIndex !== -1) {
+          const newGuesses = guesses.map((r, ri) => {
+            if (ri !== currentRow) return r;
+            const newRow = [...r];
+            newRow[colIndex] = i;
+            return newRow;
+          });
+          setGuesses(newGuesses);
+        }
+        return;
+      }
+    }
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = CANVAS_WIDTH * dpr;
+    canvas.height = CANVAS_HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+    const gradient = ctx.createRadialGradient(
+      CANVAS_WIDTH / 2,
+      CANVAS_HEIGHT / 2,
+      0,
+      CANVAS_WIDTH / 2,
+      CANVAS_HEIGHT / 2,
+      Math.max(CANVAS_WIDTH, CANVAS_HEIGHT) / 1.5
+    );
+    gradient.addColorStop(0, '#15161a');
+    gradient.addColorStop(1, '#0f0f12');
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const boardWidth = PEG_SPACING * PEGS + 60;
+    const startX = (CANVAS_WIDTH - boardWidth) / 2;
+
+    for (let r = 0; r < ROWS; r++) {
+      const y = TOP_MARGIN + r * ROW_SPACING;
+      for (let c = 0; c < PEGS; c++) {
+        const x = startX + c * PEG_SPACING;
+        ctx.beginPath();
+        ctx.arc(x, y, PEG_RADIUS, 0, Math.PI * 2);
+        const colorIndex = guesses[r][c];
+        ctx.fillStyle = colorIndex === -1 ? 'rgba(255,255,255,0.1)' : COLORS[colorIndex];
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+        ctx.stroke();
+      }
+
+      const res = results[r];
+      if (res) {
+        const fbX = startX + PEG_SPACING * PEGS + 20;
+        const fbY = y - FEEDBACK_SPACING / 2;
+        let peg = 0;
+        for (let i = 0; i < res.correct; i++) {
+          const fx = fbX + (peg % 2) * FEEDBACK_SPACING;
+          const fy = fbY + Math.floor(peg / 2) * FEEDBACK_SPACING;
+          ctx.beginPath();
+          ctx.arc(fx, fy, FEEDBACK_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = '#000';
+          ctx.fill();
+          peg++;
+        }
+        for (let i = 0; i < res.misplaced; i++) {
+          const fx = fbX + (peg % 2) * FEEDBACK_SPACING;
+          const fy = fbY + Math.floor(peg / 2) * FEEDBACK_SPACING;
+          ctx.beginPath();
+          ctx.arc(fx, fy, FEEDBACK_RADIUS, 0, Math.PI * 2);
+          ctx.fillStyle = '#fff';
+          ctx.fill();
+          peg++;
+        }
+      }
+    }
+
+    const paletteY = TOP_MARGIN + ROW_SPACING * ROWS + 60;
+    const paletteStartX = (CANVAS_WIDTH - (COLORS.length - 1) * PALETTE_SPACING) / 2;
+    for (let i = 0; i < COLORS.length; i++) {
+      const x = paletteStartX + i * PALETTE_SPACING;
+      ctx.beginPath();
+      ctx.arc(x, paletteY, PALETTE_RADIUS, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS[i];
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(255,255,255,0.2)';
+      ctx.stroke();
+    }
+
+    if (gameState === 'won' || gameState === 'lost') {
+      ctx.fillStyle = '#ffffff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      const msg = gameState === 'won'
+        ? '정답입니다!'
+        : `실패! 정답: ${secret.map(i => COLOR_NAMES[i]).join(', ')}`;
+      ctx.fillText(msg, CANVAS_WIDTH / 2, 30);
+    }
+  }, [guesses, results, secret, gameState]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['w', 'a', 's', 'd', 'r', 'z'].includes(key)) {
+        e.stopPropagation();
+      }
+      if (key === 'r') {
+        e.preventDefault();
+        resetGame();
+      } else if (key === 'z') {
+        e.preventDefault();
+        handleUndo();
+      }
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [resetGame, handleUndo]);
+
+  return (
+    <GameLayout
+      title="🧠 Mastermind"
+      topInfo={<div>시도: {currentRow + 1}/{ROWS}</div>}
+      bottomInfo={<div>팔레트에서 색을 선택해 조합을 맞추세요. Submit으로 확인, Z=Undo, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Mastermind"
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        onClick={handleCanvasClick}
+      />
+      <div style={{ marginTop: 16, display: 'flex', gap: 8 }}>
+        <GameButton
+          onClick={submitGuess}
+          disabled={guesses[currentRow].some(v => v === -1) || gameState !== 'playing'}
+        >
+          Submit
+        </GameButton>
+        <GameButton
+          onClick={handleUndo}
+          variant="secondary"
+          disabled={guesses[currentRow].every(v => v === -1) || gameState !== 'playing'}
+        >
+          Undo
+        </GameButton>
+        <GameButton onClick={resetGame} variant="secondary">
+          Reset
+        </GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MastermindCanvas;
+

--- a/src/MatchThreeCanvas.tsx
+++ b/src/MatchThreeCanvas.tsx
@@ -1,0 +1,250 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 8;
+const COLORS = ['#ff595e', '#1982c4', '#6a4c93', '#8ac926', '#ffca3a', '#ff924c'];
+const TILE = 60;
+const WIDTH = SIZE * TILE;
+const HEIGHT = WIDTH;
+
+type Board = number[][];
+
+const randomGem = () => Math.floor(Math.random() * COLORS.length);
+
+function findMatches(board: Board) {
+  const matches = new Set<string>();
+  // rows
+  for (let r = 0; r < SIZE; r++) {
+    let runColor = board[r][0];
+    let runStart = 0;
+    for (let c = 1; c <= SIZE; c++) {
+      if (c < SIZE && board[r][c] === runColor) continue;
+      if (runColor !== -1 && c - runStart >= 3) {
+        for (let i = runStart; i < c; i++) matches.add(`${r},${i}`);
+      }
+      runColor = c < SIZE ? board[r][c] : -1;
+      runStart = c;
+    }
+  }
+  // columns
+  for (let c = 0; c < SIZE; c++) {
+    let runColor = board[0][c];
+    let runStart = 0;
+    for (let r = 1; r <= SIZE; r++) {
+      if (r < SIZE && board[r][c] === runColor) continue;
+      if (runColor !== -1 && r - runStart >= 3) {
+        for (let i = runStart; i < r; i++) matches.add(`${i},${c}`);
+      }
+      runColor = r < SIZE ? board[r][c] : -1;
+      runStart = r;
+    }
+  }
+  return Array.from(matches).map(s => s.split(',').map(Number) as [number, number]);
+}
+
+function resolveBoard(board: Board) {
+  let removed = 0;
+  while (true) {
+    const matches = findMatches(board);
+    if (matches.length === 0) break;
+    removed += matches.length;
+    for (const [r, c] of matches) board[r][c] = -1;
+    for (let c = 0; c < SIZE; c++) {
+      let dest = SIZE - 1;
+      for (let r = SIZE - 1; r >= 0; r--) {
+        if (board[r][c] !== -1) {
+          board[dest][c] = board[r][c];
+          dest--;
+        }
+      }
+      for (let r = dest; r >= 0; r--) {
+        board[r][c] = randomGem();
+      }
+    }
+  }
+  return removed;
+}
+
+function createBoard(): Board {
+  const board = Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, randomGem));
+  resolveBoard(board);
+  return board;
+}
+
+const MatchThreeCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [board, setBoard] = useState<Board>(() => createBoard());
+  const [selected, setSelected] = useState<[number, number] | null>(null);
+  const [score, setScore] = useState(0);
+  const [animating, setAnimating] = useState(false);
+
+  const resetGame = useCallback(() => {
+    setBoard(createBoard());
+    setSelected(null);
+    setScore(0);
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (animating) return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / TILE);
+      const r = Math.floor(y / TILE);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      if (!selected) {
+        setSelected([r, c]);
+        return;
+      }
+      const [sr, sc] = selected;
+      if (sr === r && sc === c) {
+        setSelected(null);
+        return;
+      }
+      if (Math.abs(sr - r) + Math.abs(sc - c) !== 1) {
+        setSelected([r, c]);
+        return;
+      }
+      const original = board.map(row => row.slice());
+      const swapped = board.map(row => row.slice());
+      [swapped[sr][sc], swapped[r][c]] = [swapped[r][c], swapped[sr][sc]];
+      setSelected(null);
+      setAnimating(true);
+      const animate = () =>
+        new Promise<void>(resolve => {
+          const canvas = canvasRef.current;
+          const ctx = canvas?.getContext('2d');
+          if (!canvas || !ctx) {
+            resolve();
+            return;
+          }
+          const dpr = window.devicePixelRatio || 1;
+          canvas.width = WIDTH * dpr;
+          canvas.height = HEIGHT * dpr;
+          ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+          const [fr, fc] = [sr, sc];
+          const [tr, tc] = [r, c];
+          const fromColor = COLORS[board[fr][fc]];
+          const toColor = COLORS[board[tr][tc]];
+          let start: number | null = null;
+          const duration = 200;
+          const step = (timestamp: number) => {
+            if (start === null) start = timestamp;
+            const progress = Math.min((timestamp - start) / duration, 1);
+            ctx.fillStyle = '#222';
+            ctx.fillRect(0, 0, WIDTH, HEIGHT);
+            for (let rr = 0; rr < SIZE; rr++) {
+              for (let cc = 0; cc < SIZE; cc++) {
+                if ((rr === fr && cc === fc) || (rr === tr && cc === tc)) continue;
+                const colorIndex = board[rr][cc];
+                ctx.fillStyle = colorIndex >= 0 ? COLORS[colorIndex] : '#000';
+                ctx.fillRect(cc * TILE, rr * TILE, TILE, TILE);
+                ctx.strokeStyle = '#111';
+                ctx.strokeRect(cc * TILE, rr * TILE, TILE, TILE);
+              }
+            }
+            const fx = fc * TILE + (tc - fc) * TILE * progress;
+            const fy = fr * TILE + (tr - fr) * TILE * progress;
+            const tx = tc * TILE + (fc - tc) * TILE * progress;
+            const ty = tr * TILE + (sr - tr) * TILE * progress;
+            ctx.fillStyle = fromColor;
+            ctx.fillRect(fx, fy, TILE, TILE);
+            ctx.strokeStyle = '#111';
+            ctx.strokeRect(fx, fy, TILE, TILE);
+            ctx.fillStyle = toColor;
+            ctx.fillRect(tx, ty, TILE, TILE);
+            ctx.strokeStyle = '#111';
+            ctx.strokeRect(tx, ty, TILE, TILE);
+            if (progress < 1) {
+              requestAnimationFrame(step);
+            } else {
+              resolve();
+            }
+          };
+          requestAnimationFrame(step);
+        });
+      animate().then(() => {
+        const resolved = swapped.map(row => row.slice());
+        const cleared = resolveBoard(resolved);
+        if (cleared > 0) {
+          setScore(s => s + cleared);
+          setBoard(resolved);
+        } else {
+          setBoard(original);
+        }
+        setAnimating(false);
+      });
+    },
+    [board, selected, animating]
+  );
+
+  useEffect(() => {
+    if (animating) return;
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const colorIndex = board[r][c];
+        ctx.fillStyle = colorIndex >= 0 ? COLORS[colorIndex] : '#000';
+        ctx.fillRect(c * TILE, r * TILE, TILE, TILE);
+        ctx.strokeStyle = '#111';
+        ctx.strokeRect(c * TILE, r * TILE, TILE, TILE);
+      }
+    }
+    if (selected) {
+      const [r, c] = selected;
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(c * TILE + 2, r * TILE + 2, TILE - 4, TILE - 4);
+    }
+  }, [board, selected, animating]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['w', 'a', 's', 'd', 'r'].includes(key)) {
+        e.stopPropagation();
+      }
+      if (key === 'r') {
+        e.preventDefault();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="💎 Match-3"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>인접한 보석을 클릭해 교환하세요. 3개 이상 매치하면 제거됩니다. R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Match-3"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MatchThreeCanvas;
+

--- a/src/MinesweeperCanvas.tsx
+++ b/src/MinesweeperCanvas.tsx
@@ -1,0 +1,208 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 10;
+const MINES = 10;
+const CELL = 32;
+const WIDTH = SIZE * CELL;
+const HEIGHT = SIZE * CELL;
+
+interface Cell {
+  mine: boolean;
+  revealed: boolean;
+  flagged: boolean;
+  adjacent: number;
+}
+
+function createBoard(): Cell[][] {
+  const board: Cell[][] = Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, () => ({ mine: false, revealed: false, flagged: false, adjacent: 0 }))
+  );
+  let placed = 0;
+  while (placed < MINES) {
+    const r = Math.floor(Math.random() * SIZE);
+    const c = Math.floor(Math.random() * SIZE);
+    if (board[r][c].mine) continue;
+    board[r][c].mine = true;
+    placed++;
+  }
+  for (let r = 0; r < SIZE; r++) {
+    for (let c = 0; c < SIZE; c++) {
+      if (board[r][c].mine) continue;
+      let count = 0;
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const nr = r + dr;
+          const nc = c + dc;
+          if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) continue;
+          if (board[nr][nc].mine) count++;
+        }
+      }
+      board[r][c].adjacent = count;
+    }
+  }
+  return board;
+}
+
+const MinesweeperCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [board, setBoard] = useState<Cell[][]>(() => createBoard());
+  const [state, setState] = useState<'playing' | 'won' | 'lost'>('playing');
+  const [flags, setFlags] = useState(0);
+
+  const resetGame = useCallback(() => {
+    setBoard(createBoard());
+    setState('playing');
+    setFlags(0);
+  }, []);
+
+  const flood = useCallback((b: Cell[][], r: number, c: number) => {
+    const cell = b[r][c];
+    if (cell.revealed || cell.flagged) return;
+    cell.revealed = true;
+    if (cell.mine) {
+      setState('lost');
+      return;
+    }
+    if (cell.adjacent === 0) {
+      for (let dr = -1; dr <= 1; dr++) {
+        for (let dc = -1; dc <= 1; dc++) {
+          const nr = r + dr;
+          const nc = c + dc;
+          if (nr < 0 || nr >= SIZE || nc < 0 || nc >= SIZE) continue;
+          flood(b, nr, nc);
+        }
+      }
+    }
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      const newBoard = board.map(row => row.map(cell => ({ ...cell })));
+      flood(newBoard, r, c);
+      const cleared = newBoard.every(row => row.every(cell => cell.revealed || cell.mine));
+      if (cleared && state === 'playing') setState('won');
+      setBoard(newBoard);
+    },
+    [board, flood, state]
+  );
+
+  const handleRightClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      const newBoard = board.map(row => row.map(cell => ({ ...cell })));
+      const cell = newBoard[r][c];
+      if (cell.revealed) return;
+      cell.flagged = !cell.flagged;
+      setFlags(f => f + (cell.flagged ? 1 : -1));
+      setBoard(newBoard);
+    },
+    [board, state]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const cell = board[r][c];
+        const x = c * CELL;
+        const y = r * CELL;
+        ctx.strokeStyle = '#555';
+        ctx.strokeRect(x, y, CELL, CELL);
+        if (cell.revealed) {
+          ctx.fillStyle = '#333';
+          ctx.fillRect(x, y, CELL, CELL);
+          if (cell.mine) {
+            ctx.fillStyle = 'red';
+            ctx.beginPath();
+            ctx.arc(x + CELL / 2, y + CELL / 2, CELL / 4, 0, Math.PI * 2);
+            ctx.fill();
+          } else if (cell.adjacent > 0) {
+            ctx.fillStyle = '#fff';
+            ctx.font = '16px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(String(cell.adjacent), x + CELL / 2, y + CELL / 2);
+          }
+        } else {
+          ctx.fillStyle = '#444';
+          ctx.fillRect(x, y, CELL, CELL);
+          if (cell.flagged) {
+            ctx.fillStyle = 'yellow';
+            ctx.beginPath();
+            ctx.moveTo(x + CELL * 0.3, y + CELL * 0.7);
+            ctx.lineTo(x + CELL * 0.5, y + CELL * 0.3);
+            ctx.lineTo(x + CELL * 0.7, y + CELL * 0.7);
+            ctx.closePath();
+            ctx.fill();
+          }
+        }
+      }
+    }
+    if (state === 'won' || state === 'lost') {
+      ctx.fillStyle = '#fff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      const msg = state === 'won' ? '승리!' : '실패!';
+      ctx.fillText(msg, WIDTH / 2, HEIGHT / 2);
+    }
+  }, [board, state]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="💣 Minesweeper"
+      topInfo={<div>Flags: {flags}/{MINES}</div>}
+      bottomInfo={<div>좌클릭: 열기, 우클릭: 깃발, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Minesweeper"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default MinesweeperCanvas;

--- a/src/PaperIoCanvas.tsx
+++ b/src/PaperIoCanvas.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const COLS = 30;
+const ROWS = 20;
+const CELL = 20;
+
+type Cell = 0 | 1 | 2; // 0 empty, 1 territory, 2 trail
+
+type Dir = 'L' | 'R' | 'U' | 'D';
+interface Pt { x: number; y: number; }
+
+export default function PaperIoCanvas() {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gridRef = useRef<Cell[][]>(
+    Array.from({ length: ROWS }, () => Array<Cell>(COLS).fill(0))
+  );
+  const headRef = useRef<Pt>({ x: Math.floor(COLS / 2), y: Math.floor(ROWS / 2) });
+  const dirRef = useRef<Dir>('R');
+  const trailRef = useRef<Pt[]>([]);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'playing' | 'over'>('playing');
+
+  const initGrid = useCallback(() => {
+    const grid = gridRef.current;
+    for (let y = 0; y < ROWS; y++)
+      for (let x = 0; x < COLS; x++) grid[y][x] = 0;
+    const cx = Math.floor(COLS / 2);
+    const cy = Math.floor(ROWS / 2);
+    for (let y = cy - 2; y <= cy + 2; y++)
+      for (let x = cx - 2; x <= cx + 2; x++) grid[y][x] = 1;
+    headRef.current = { x: cx, y: cy };
+    dirRef.current = 'R';
+    trailRef.current = [];
+    setScore(25);
+    setState('playing');
+  }, []);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        const cell = gridRef.current[y][x];
+        if (cell === 1) ctx.fillStyle = '#ffd166';
+        else if (cell === 2) ctx.fillStyle = '#ef476f';
+        else ctx.fillStyle = '#073b4c';
+        ctx.fillRect(x * CELL, y * CELL, CELL, CELL);
+      }
+    }
+    ctx.fillStyle = '#06d6a0';
+    const h = headRef.current;
+    ctx.fillRect(h.x * CELL, h.y * CELL, CELL, CELL);
+  }, []);
+
+  const captureArea = () => {
+    const grid = gridRef.current;
+    const visited = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+    const q: Pt[] = [];
+    const push = (p: Pt) => {
+      if (
+        p.x >= 0 && p.x < COLS &&
+        p.y >= 0 && p.y < ROWS &&
+        !visited[p.y][p.x] &&
+        grid[p.y][p.x] === 0
+      ) {
+        visited[p.y][p.x] = true;
+        q.push(p);
+      }
+    };
+    for (let x = 0; x < COLS; x++) {
+      push({ x, y: 0 });
+      push({ x, y: ROWS - 1 });
+    }
+    for (let y = 0; y < ROWS; y++) {
+      push({ x: 0, y });
+      push({ x: COLS - 1, y });
+    }
+    for (let i = 0; i < q.length; i++) {
+      const { x, y } = q[i];
+      push({ x: x + 1, y });
+      push({ x: x - 1, y });
+      push({ x, y: y + 1 });
+      push({ x, y: y - 1 });
+    }
+    let gained = 0;
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        if (grid[y][x] === 0 && !visited[y][x]) {
+          grid[y][x] = 1;
+          gained++;
+        }
+        if (grid[y][x] === 2) {
+          grid[y][x] = 1;
+          gained++;
+        }
+      }
+    }
+    trailRef.current = [];
+    setScore((s) => s + gained);
+  };
+
+  useEffect(() => {
+    const canvas = canvasRef.current!;
+    canvas.width = COLS * CELL;
+    canvas.height = ROWS * CELL;
+    initGrid();
+    draw();
+    const interval = setInterval(() => {
+      if (state !== 'playing') return;
+      const head = headRef.current;
+      const dir = dirRef.current;
+      const next = { x: head.x + (dir === 'L' ? -1 : dir === 'R' ? 1 : 0), y: head.y + (dir === 'U' ? -1 : dir === 'D' ? 1 : 0) };
+      if (
+        next.x < 0 ||
+        next.x >= COLS ||
+        next.y < 0 ||
+        next.y >= ROWS
+      ) {
+        setState('over');
+        return;
+      }
+      const cell = gridRef.current[next.y][next.x];
+      if (cell === 2) {
+        setState('over');
+        return;
+      }
+      headRef.current = next;
+      if (cell === 0) {
+        gridRef.current[next.y][next.x] = 2;
+        trailRef.current.push(next);
+      } else if (cell === 1 && trailRef.current.length > 0) {
+        captureArea();
+      }
+      draw();
+    }, 120);
+    return () => clearInterval(interval);
+  }, [draw, initGrid, state]);
+
+  const resetGame = useCallback(() => {
+    initGrid();
+    draw();
+  }, [draw, initGrid]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['arrowleft', 'arrowright', 'arrowup', 'arrowdown'].includes(key)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      if (['w', 'a', 's', 'd', 'r'].includes(key)) e.stopPropagation();
+      if (key === 'r') {
+        resetGame();
+        return;
+      }
+      const dirMap: Record<string, Dir> = {
+        arrowleft: 'L',
+        a: 'L',
+        arrowright: 'R',
+        d: 'R',
+        arrowup: 'U',
+        w: 'U',
+        arrowdown: 'D',
+        s: 'D',
+      };
+      const nd = dirMap[key];
+      if (nd) dirRef.current = nd;
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="📄 Paper.io"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>WASD/Arrow 이동, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Paper.io"
+        width={COLS * CELL}
+        height={ROWS * CELL}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+}

--- a/src/PenguinJumpCanvas.tsx
+++ b/src/PenguinJumpCanvas.tsx
@@ -1,0 +1,226 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+interface Platform {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const GRAVITY = 1500; // px/s^2
+const SPEED = 200; // horizontal speed
+const JUMP_VELOCITY = -600; // jump impulse
+
+const platforms: Platform[] = [
+  { x: 0, y: CANVAS_HEIGHT - 40, width: CANVAS_WIDTH, height: 40 },
+  { x: 80, y: CANVAS_HEIGHT - 140, width: 120, height: 20 },
+  { x: 260, y: CANVAS_HEIGHT - 220, width: 120, height: 20 },
+  { x: 460, y: CANVAS_HEIGHT - 180, width: 120, height: 20 },
+];
+
+const PenguinJumpCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+
+  const [score, setScore] = useState(0);
+
+  const playerRef = useRef({
+    x: 40,
+    y: CANVAS_HEIGHT - 80,
+    vx: 0,
+    vy: 0,
+    width: 40,
+    height: 40,
+    onGround: false,
+  });
+
+  const keys = useRef({ left: false, right: false });
+
+  const resetPlayer = useCallback(() => {
+    playerRef.current = {
+      x: 40,
+      y: CANVAS_HEIGHT - 80,
+      vx: 0,
+      vy: 0,
+      width: 40,
+      height: 40,
+      onGround: false,
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    setScore(0);
+    resetPlayer();
+  }, [resetPlayer]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (['a', 'd', 'w', ' ', 'ArrowLeft', 'ArrowRight', 'ArrowUp'].includes(e.key)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    switch (e.key) {
+      case 'a':
+      case 'ArrowLeft':
+        keys.current.left = true;
+        break;
+      case 'd':
+      case 'ArrowRight':
+        keys.current.right = true;
+        break;
+      case 'w':
+      case 'ArrowUp':
+      case ' ': // space
+        if (playerRef.current.onGround) {
+          playerRef.current.vy = JUMP_VELOCITY;
+          playerRef.current.onGround = false;
+        }
+        break;
+    }
+  }, []);
+
+  const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    if (['a', 'd', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    switch (e.key) {
+      case 'a':
+      case 'ArrowLeft':
+        keys.current.left = false;
+        break;
+      case 'd':
+      case 'ArrowRight':
+        keys.current.right = false;
+        break;
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [handleKeyDown, handleKeyUp]);
+
+  const update = useCallback((dt: number) => {
+    const player = playerRef.current;
+
+    // horizontal movement
+    if (keys.current.left) player.vx = -SPEED;
+    else if (keys.current.right) player.vx = SPEED;
+    else player.vx = 0;
+
+    // apply gravity
+    player.vy += GRAVITY * dt;
+
+    // update position
+    player.x += player.vx * dt;
+    player.y += player.vy * dt;
+
+    // bounds
+    player.x = Math.max(0, Math.min(CANVAS_WIDTH - player.width, player.x));
+
+    // collision detection
+    player.onGround = false;
+    for (const p of platforms) {
+      const prevBottom = player.y - player.vy * dt + player.height;
+      const currBottom = player.y + player.height;
+      if (
+        player.x < p.x + p.width &&
+        player.x + player.width > p.x &&
+        prevBottom <= p.y &&
+        currBottom >= p.y &&
+        player.vy >= 0
+      ) {
+        player.y = p.y - player.height;
+        player.vy = 0;
+        player.onGround = true;
+      }
+    }
+
+    // fell off
+    if (player.y > CANVAS_HEIGHT) {
+      resetPlayer();
+    }
+
+    // goal flag at right
+    if (player.x + player.width >= CANVAS_WIDTH - 30 && player.onGround) {
+      setScore((s) => s + 1);
+      resetPlayer();
+    }
+  }, [resetPlayer]);
+
+  const draw = useCallback((ctx: CanvasRenderingContext2D) => {
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    // platforms
+    ctx.fillStyle = '#654321';
+    platforms.forEach((p) => {
+      ctx.fillRect(p.x, p.y, p.width, p.height);
+    });
+
+    // goal flag
+    const ground = platforms[0];
+    ctx.fillStyle = '#ff0000';
+    ctx.fillRect(CANVAS_WIDTH - 20, ground.y - 60, 5, 60);
+    ctx.fillRect(CANVAS_WIDTH - 20, ground.y - 60, 20, 15);
+
+    // penguin character
+    const player = playerRef.current;
+    ctx.font = `${player.width}px serif`;
+    ctx.textBaseline = 'bottom';
+    ctx.fillText('🐧', player.x, player.y + player.height);
+  }, []);
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    let last = performance.now();
+
+    const loop = (time: number) => {
+      const dt = (time - last) / 1000;
+      last = time;
+      update(dt);
+      draw(ctx);
+      animationRef.current = requestAnimationFrame(loop);
+    };
+    animationRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animationRef.current!);
+  }, [update, draw]);
+
+  const gameStats = <div style={{ textAlign: 'center' }}>점수: {score}</div>;
+  const instructions = 'A/D 또는 ←→로 이동, W/Space/↑로 점프하세요. 오른쪽 끝 깃발에 닿으면 점수를 얻습니다.';
+  const actionButtons = (
+    <GameButton onClick={reset} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  return (
+    <GameManager
+      title="Penguin Jump"
+      gameIcon="🐧"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        gameTitle="Penguin Jump"
+      />
+    </GameManager>
+  );
+};
+
+export default PenguinJumpCanvas;
+

--- a/src/PicrossCanvas.tsx
+++ b/src/PicrossCanvas.tsx
@@ -1,0 +1,217 @@
+import React, { useRef, useState, useEffect, useCallback } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const SIZE = 10;
+const CELL = 32;
+const HINT = 40;
+const WIDTH = HINT + SIZE * CELL;
+const HEIGHT = HINT + SIZE * CELL;
+
+type CellState = 0 | 1 | 2; // empty, filled, marked
+
+function createPuzzle(): boolean[][] {
+  return Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, () => Math.random() < 0.5)
+  );
+}
+
+function createBoard(): CellState[][] {
+  return Array.from({ length: SIZE }, () => Array<CellState>(SIZE).fill(0));
+}
+
+function computeHints(puzzle: boolean[][]) {
+  const rows = puzzle.map((row) => {
+    const hints: number[] = [];
+    let count = 0;
+    for (const cell of row) {
+      if (cell) count++;
+      else if (count) {
+        hints.push(count);
+        count = 0;
+      }
+    }
+    if (count) hints.push(count);
+    return hints.length ? hints : [0];
+  });
+  const cols = Array.from({ length: SIZE }, (_, c) => {
+    const hints: number[] = [];
+    let count = 0;
+    for (let r = 0; r < SIZE; r++) {
+      if (puzzle[r][c]) count++;
+      else if (count) {
+        hints.push(count);
+        count = 0;
+      }
+    }
+    if (count) hints.push(count);
+    return hints.length ? hints : [0];
+  });
+  return { rows, cols };
+}
+
+const PicrossCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [puzzle, setPuzzle] = useState<boolean[][]>(() => createPuzzle());
+  const [board, setBoard] = useState<CellState[][]>(() => createBoard());
+  const [hints, setHints] = useState(() => computeHints(puzzle));
+  const [state, setState] = useState<'playing' | 'won'>('playing');
+
+  const resetGame = useCallback(() => {
+    const p = createPuzzle();
+    setPuzzle(p);
+    setBoard(createBoard());
+    setHints(computeHints(p));
+    setState('playing');
+  }, []);
+
+  const checkWin = useCallback((b: CellState[][], p: boolean[][]) => {
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const filled = b[r][c] === 1;
+        if (filled !== p[r][c]) return false;
+      }
+    }
+    return true;
+  }, []);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH - HINT;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT - HINT;
+      if (x < 0 || y < 0) return;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      const newBoard = board.map((row) => row.slice());
+      newBoard[r][c] = newBoard[r][c] === 1 ? 0 : 1;
+      if (checkWin(newBoard, puzzle)) setState('won');
+      setBoard(newBoard);
+    },
+    [board, checkWin, puzzle, state]
+  );
+
+  const handleRightClick = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>) => {
+      e.preventDefault();
+      if (state !== 'playing') return;
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * WIDTH - HINT;
+      const y = ((e.clientY - rect.top) / rect.height) * HEIGHT - HINT;
+      if (x < 0 || y < 0) return;
+      const c = Math.floor(x / CELL);
+      const r = Math.floor(y / CELL);
+      if (r < 0 || r >= SIZE || c < 0 || c >= SIZE) return;
+      const newBoard = board.map((row) => row.slice());
+      newBoard[r][c] = newBoard[r][c] === 2 ? 0 : 2;
+      setBoard(newBoard);
+    },
+    [board, state]
+  );
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, WIDTH, HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+    // draw hints
+    ctx.fillStyle = '#fff';
+    ctx.font = '14px sans-serif';
+    ctx.textAlign = 'right';
+    ctx.textBaseline = 'middle';
+    for (let r = 0; r < SIZE; r++) {
+      const rowHints = hints.rows[r];
+      for (let i = 0; i < rowHints.length; i++) {
+        const num = rowHints[rowHints.length - 1 - i];
+        ctx.fillText(String(num), HINT - 4 - i * 14, HINT + r * CELL + CELL / 2);
+      }
+    }
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'bottom';
+    for (let c = 0; c < SIZE; c++) {
+      const colHints = hints.cols[c];
+      for (let i = 0; i < colHints.length; i++) {
+        const num = colHints[colHints.length - 1 - i];
+        ctx.fillText(String(num), HINT + c * CELL + CELL / 2, HINT - 4 - i * 14);
+      }
+    }
+
+    // draw grid and cells
+    for (let r = 0; r < SIZE; r++) {
+      for (let c = 0; c < SIZE; c++) {
+        const x = HINT + c * CELL;
+        const y = HINT + r * CELL;
+        ctx.strokeStyle = '#555';
+        ctx.strokeRect(x, y, CELL, CELL);
+        const val = board[r][c];
+        if (val === 1) {
+          ctx.fillStyle = '#fff';
+          ctx.fillRect(x + 2, y + 2, CELL - 4, CELL - 4);
+        } else if (val === 2) {
+          ctx.strokeStyle = '#888';
+          ctx.beginPath();
+          ctx.moveTo(x + 4, y + 4);
+          ctx.lineTo(x + CELL - 4, y + CELL - 4);
+          ctx.moveTo(x + CELL - 4, y + 4);
+          ctx.lineTo(x + 4, y + CELL - 4);
+          ctx.stroke();
+        } else {
+          ctx.fillStyle = '#333';
+          ctx.fillRect(x + 1, y + 1, CELL - 2, CELL - 2);
+        }
+      }
+    }
+
+    if (state === 'won') {
+      ctx.fillStyle = '#fff';
+      ctx.font = '20px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('완료!', WIDTH / 2, HEIGHT / 2);
+    }
+  }, [board, hints, state]);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === 'r') {
+        e.preventDefault();
+        e.stopPropagation();
+        resetGame();
+      }
+    };
+    window.addEventListener('keydown', onKey, { capture: true });
+    return () => window.removeEventListener('keydown', onKey, { capture: true });
+  }, [resetGame]);
+
+  return (
+    <GameLayout
+      title="🖼️ Picross"
+      bottomInfo={<div>좌클릭: 칸 채우기, 우클릭: X, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Picross"
+        width={WIDTH}
+        height={HEIGHT}
+        onClick={handleClick}
+        onContextMenu={handleRightClick}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default PicrossCanvas;

--- a/src/PumpItUpCanvas.tsx
+++ b/src/PumpItUpCanvas.tsx
@@ -1,0 +1,195 @@
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const WIDTH = 300;
+const HEIGHT = 600;
+const LANE_WIDTH = WIDTH / 4;
+const TARGET_Y = HEIGHT - 100;
+const NOTE_SPEED = 240; // px per second
+const SPAWN_INTERVAL = 800; // ms
+const HIT_WINDOW = 50;
+const MAX_MISSES = 5;
+const KEYS = ['q', 'w', 'e', 'r'];
+
+type Note = {
+  lane: number;
+  y: number;
+  state: 'active' | 'hit' | 'miss';
+  timer: number;
+};
+
+const PumpItUpCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const notesRef = useRef<Note[]>([]);
+  const spawnRef = useRef(0);
+  const flashRef = useRef([0, 0, 0, 0]);
+  const [score, setScore] = useState(0);
+  const [misses, setMisses] = useState(0);
+  const [state, setState] = useState<'playing' | 'over'>('playing');
+
+  const resetGame = useCallback(() => {
+    notesRef.current = [];
+    spawnRef.current = 0;
+    setScore(0);
+    setMisses(0);
+    setState('playing');
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = WIDTH * dpr;
+    canvas.height = HEIGHT * dpr;
+    ctx.scale(dpr, dpr);
+
+    let prev: number | null = null;
+    let rafId: number;
+    const loop = (time: number) => {
+      if (prev === null) prev = time;
+      const delta = time - prev;
+      prev = time;
+
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+      ctx.clearRect(0, 0, WIDTH, HEIGHT);
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, WIDTH, HEIGHT);
+
+      // draw target lanes
+        ctx.fillStyle = '#444';
+        for (let i = 0; i < 4; i++) {
+          ctx.fillRect(i * LANE_WIDTH, 0, 2, HEIGHT);
+          ctx.fillRect(i * LANE_WIDTH, TARGET_Y, LANE_WIDTH, 10);
+        }
+
+      // lane key hints
+      ctx.font = '64px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'bottom';
+      for (let i = 0; i < 4; i++) {
+        flashRef.current[i] = Math.max(0, flashRef.current[i] - delta);
+        ctx.fillStyle = flashRef.current[i]
+          ? 'rgba(255,255,255,0.6)'
+          : 'rgba(255,255,255,0.1)';
+        ctx.fillText(KEYS[i].toUpperCase(), i * LANE_WIDTH + LANE_WIDTH / 2, HEIGHT - 10);
+      }
+
+      if (state === 'playing') {
+        spawnRef.current += delta;
+        if (spawnRef.current > SPAWN_INTERVAL) {
+          spawnRef.current -= SPAWN_INTERVAL;
+          notesRef.current.push({
+            lane: Math.floor(Math.random() * 4),
+            y: -20,
+            state: 'active',
+            timer: 0,
+          });
+        }
+      }
+
+      for (const note of notesRef.current) {
+        if (note.state === 'active' && state === 'playing') {
+          note.y += NOTE_SPEED * (delta / 1000);
+        } else {
+          note.timer -= delta;
+        }
+        const color =
+          note.state === 'hit'
+            ? '#0f0'
+            : note.state === 'miss'
+            ? '#f00'
+            : '#0bf';
+        ctx.fillStyle = color;
+        const x = note.lane * LANE_WIDTH + LANE_WIDTH / 2;
+        ctx.beginPath();
+        ctx.arc(x, note.y, 20, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // handle misses and clean-up
+      if (state === 'playing') {
+        for (const n of notesRef.current) {
+          if (n.state === 'active' && n.y > TARGET_Y + HIT_WINDOW) {
+            n.state = 'miss';
+            n.timer = 300;
+            setMisses((m) => {
+              const nm = m + 1;
+              if (nm >= MAX_MISSES) setState('over');
+              return nm;
+            });
+          }
+        }
+      }
+
+      notesRef.current = notesRef.current.filter(
+        (n) => n.state === 'active' || n.timer > 0
+      );
+
+      if (state === 'over') {
+        ctx.fillStyle = '#fff';
+        ctx.font = '20px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('Game Over', WIDTH / 2, HEIGHT / 2);
+      }
+
+      rafId = requestAnimationFrame(loop);
+    };
+    rafId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(rafId);
+  }, [state]);
+
+  const handleKey = useCallback(
+    (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if ([...KEYS, ' '].includes(key)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      if (key === ' ') {
+        resetGame();
+        return;
+      }
+      if (state !== 'playing') return;
+      let lane: number | null = null;
+      if (key === 'q') lane = 0;
+      else if (key === 'w') lane = 1;
+      else if (key === 'e') lane = 2;
+      else if (key === 'r') lane = 3;
+      if (lane === null) return;
+      flashRef.current[lane] = 100;
+      const note = notesRef.current.find(
+        (n) => n.lane === lane && n.state === 'active' && Math.abs(n.y - TARGET_Y) < HIT_WINDOW
+      );
+      if (note) {
+        note.state = 'hit';
+        note.timer = 300;
+        setScore((s) => s + 1);
+      }
+    },
+    [resetGame, state]
+  );
+
+  useEffect(() => {
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [handleKey]);
+
+  return (
+    <GameLayout
+      title="🎵 Pump It Up"
+      topInfo={<div>Score: {score} Misses: {misses}/{MAX_MISSES}</div>}
+      bottomInfo={<div>Q W E R : Hit • Space : Reset</div>}
+    >
+      <GameCanvas ref={canvasRef} gameTitle="Pump It Up" width={WIDTH} height={HEIGHT} />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default PumpItUpCanvas;

--- a/src/PuyoPuyoCanvas.tsx
+++ b/src/PuyoPuyoCanvas.tsx
@@ -1,0 +1,272 @@
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback
+} from 'react';
+import GameLayout from './components/GameLayout';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+
+const COLS = 6;
+const ROWS = 12;
+const CELL = 30;
+const COLORS = ['#ff595e', '#1982c4', '#6a4c93', '#8ac926'];
+
+interface Pair {
+  x: number;
+  y: number;
+  rotation: number; // 0 up, 1 right, 2 down, 3 left
+  colors: [number, number];
+}
+
+const randColor = () => Math.floor(Math.random() * COLORS.length);
+
+const PuyoPuyoCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const gridRef = useRef<number[][]>(
+    Array.from({ length: ROWS }, () => Array(COLS).fill(-1))
+  );
+  const pairRef = useRef<Pair | null>(null);
+  const [score, setScore] = useState(0);
+  const [state, setState] = useState<'playing' | 'over'>('playing');
+
+  const getBlocks = (p: Pair) => {
+    const blocks = [{ x: p.x, y: p.y, color: p.colors[0] }];
+    let dx = 0,
+      dy = -1;
+    if (p.rotation % 4 === 1) {
+      dx = 1;
+      dy = 0;
+    } else if (p.rotation % 4 === 2) {
+      dy = 1;
+    } else if (p.rotation % 4 === 3) {
+      dx = -1;
+      dy = 0;
+    }
+    blocks.push({ x: p.x + dx, y: p.y + dy, color: p.colors[1] });
+    return blocks;
+  };
+
+  const canMove = (dx: number, dy: number, rotDelta: number) => {
+    const p = pairRef.current;
+    if (!p) return false;
+    const newPair: Pair = {
+      x: p.x + dx,
+      y: p.y + dy,
+      rotation: (p.rotation + rotDelta + 4) % 4,
+      colors: p.colors,
+    };
+    const blocks = getBlocks(newPair);
+    return blocks.every(
+      (b) =>
+        b.x >= 0 &&
+        b.x < COLS &&
+        b.y < ROWS &&
+        (b.y < 0 || gridRef.current[b.y][b.x] === -1)
+    );
+  };
+
+  const spawnPair = useCallback(() => {
+    pairRef.current = {
+      x: 2,
+      y: 0,
+      rotation: 0,
+      colors: [randColor(), randColor()],
+    };
+    if (!canMove(0, 0, 0)) setState('over');
+  }, [canMove]);
+
+  const clearMatches = useCallback(() => {
+    const visited = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+    const toClear = Array.from({ length: ROWS }, () => Array(COLS).fill(false));
+    const dirs = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1],
+    ];
+    let removed = false;
+
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        const color = gridRef.current[y][x];
+        if (color === -1 || visited[y][x]) continue;
+        const stack = [[x, y]];
+        const cells = [[x, y]];
+        visited[y][x] = true;
+        while (stack.length) {
+          const [cx, cy] = stack.pop()!;
+          for (const [dx, dy] of dirs) {
+            const nx = cx + dx;
+            const ny = cy + dy;
+            if (
+              nx >= 0 &&
+              nx < COLS &&
+              ny >= 0 &&
+              ny < ROWS &&
+              !visited[ny][nx] &&
+              gridRef.current[ny][nx] === color
+            ) {
+              visited[ny][nx] = true;
+              stack.push([nx, ny]);
+              cells.push([nx, ny]);
+            }
+          }
+        }
+        if (cells.length >= 4) {
+          removed = true;
+          cells.forEach(([cx, cy]) => (toClear[cy][cx] = true));
+          setScore((s) => s + cells.length);
+        }
+      }
+    }
+
+    if (removed) {
+      for (let y = 0; y < ROWS; y++) {
+        for (let x = 0; x < COLS; x++) {
+          if (toClear[y][x]) gridRef.current[y][x] = -1;
+        }
+      }
+      for (let x = 0; x < COLS; x++) {
+        const col: number[] = [];
+        for (let y = ROWS - 1; y >= 0; y--) {
+          const val = gridRef.current[y][x];
+          if (val !== -1) col.push(val);
+        }
+        for (let y = 0; y < ROWS; y++) gridRef.current[y][x] = -1;
+        for (let y = 0; y < col.length; y++) {
+          gridRef.current[ROWS - 1 - y][x] = col[y];
+        }
+      }
+      clearMatches();
+    }
+  }, []);
+
+  const lockPair = useCallback(() => {
+    const p = pairRef.current!;
+    const blocks = getBlocks(p);
+    blocks.forEach((b) => {
+      if (b.y >= 0 && b.y < ROWS) gridRef.current[b.y][b.x] = b.color;
+    });
+    pairRef.current = null;
+    clearMatches();
+  }, [clearMatches]);
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    ctx.clearRect(0, 0, COLS * CELL, ROWS * CELL);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, COLS * CELL, ROWS * CELL);
+    for (let y = 0; y < ROWS; y++) {
+      for (let x = 0; x < COLS; x++) {
+        const val = gridRef.current[y][x];
+        if (val !== -1) {
+          ctx.fillStyle = COLORS[val];
+          ctx.beginPath();
+          ctx.arc(
+            x * CELL + CELL / 2,
+            y * CELL + CELL / 2,
+            CELL / 2 - 2,
+            0,
+            Math.PI * 2
+          );
+          ctx.fill();
+        }
+      }
+    }
+    if (pairRef.current) {
+      const blocks = getBlocks(pairRef.current);
+      blocks.forEach((b) => {
+        ctx.fillStyle = COLORS[b.color];
+        ctx.beginPath();
+        ctx.arc(
+          b.x * CELL + CELL / 2,
+          b.y * CELL + CELL / 2,
+          CELL / 2 - 2,
+          0,
+          Math.PI * 2
+        );
+        ctx.fill();
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = COLS * CELL;
+    canvas.height = ROWS * CELL;
+    draw();
+    const interval = setInterval(() => {
+      if (state !== 'playing') return;
+      if (!pairRef.current) spawnPair();
+      else if (canMove(0, 1, 0)) pairRef.current.y++;
+      else lockPair();
+      draw();
+    }, 500);
+    return () => clearInterval(interval);
+  }, [draw, lockPair, spawnPair, state]);
+
+  const resetGame = useCallback(() => {
+    gridRef.current = Array.from({ length: ROWS }, () => Array(COLS).fill(-1));
+    pairRef.current = null;
+    setScore(0);
+    setState('playing');
+  }, []);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      if (['arrowleft', 'arrowright', 'arrowdown', 'arrowup'].includes(key)) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+      if (['a', 'd', 's', 'w', 'r'].includes(key)) {
+        e.stopPropagation();
+      }
+      if (key === 'r') {
+        resetGame();
+        return;
+      }
+      if (state !== 'playing' || !pairRef.current) return;
+      if (key === 'a' && canMove(-1, 0, 0)) {
+        pairRef.current.x--;
+      } else if (key === 'd' && canMove(1, 0, 0)) {
+        pairRef.current.x++;
+      } else if (key === 's' && canMove(0, 1, 0)) {
+        pairRef.current.y++;
+      } else if (key === 'w' && canMove(0, 0, 1)) {
+        pairRef.current.rotation = (pairRef.current.rotation + 1) % 4;
+      }
+      draw();
+    };
+    window.addEventListener('keydown', handleKey, { capture: true });
+    return () => window.removeEventListener('keydown', handleKey, { capture: true });
+  }, [canMove, draw, resetGame, state]);
+
+  return (
+    <GameLayout
+      title="🍡 Puyo Puyo"
+      topInfo={<div>Score: {score}</div>}
+      bottomInfo={<div>A/D 좌우, S 아래, W 회전, R=Reset</div>}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        gameTitle="Puyo Puyo"
+        width={COLS * CELL}
+        height={ROWS * CELL}
+      />
+      <div style={{ marginTop: 16 }}>
+        <GameButton onClick={resetGame}>Reset</GameButton>
+      </div>
+    </GameLayout>
+  );
+};
+
+export default PuyoPuyoCanvas;
+

--- a/src/SlidePuzzleCanvas.tsx
+++ b/src/SlidePuzzleCanvas.tsx
@@ -15,8 +15,10 @@ interface GameStats {
 
 const GRID_SIZE = 4;
 const CANVAS_SIZE = 480;
-const TILE_SIZE = (CANVAS_SIZE - 50) / GRID_SIZE;
 const TILE_GAP = 10;
+const TILE_SIZE = (CANVAS_SIZE - (GRID_SIZE + 1) * TILE_GAP) / GRID_SIZE;
+const BOARD_SIZE = GRID_SIZE * TILE_SIZE + (GRID_SIZE - 1) * TILE_GAP;
+const START = (CANVAS_SIZE - BOARD_SIZE) / 2;
 
 // 타일 색상
 const TILE_COLORS = {
@@ -163,8 +165,8 @@ const SlidePuzzleCanvas: React.FC = () => {
 
   // 캔버스에서 클릭된 타일 인덱스 계산
   const getTileFromPosition = useCallback((x: number, y: number): number | null => {
-    const startX = 25;
-    const startY = 25;
+    const startX = START;
+    const startY = START;
     
     const col = Math.floor((x - startX) / (TILE_SIZE + TILE_GAP));
     const row = Math.floor((y - startY) / (TILE_SIZE + TILE_GAP));
@@ -263,14 +265,14 @@ const SlidePuzzleCanvas: React.FC = () => {
 
     // 그리드 배경
     ctx.fillStyle = '#E9ECEF';
-    ctx.fillRect(15, 15, CANVAS_SIZE - 30, CANVAS_SIZE - 30);
+    ctx.fillRect(START, START, BOARD_SIZE, BOARD_SIZE);
 
     // 타일 그리기
     for (let i = 0; i < 16; i++) {
       const row = Math.floor(i / GRID_SIZE);
       const col = i % GRID_SIZE;
-      const x = 25 + col * (TILE_SIZE + TILE_GAP);
-      const y = 25 + row * (TILE_SIZE + TILE_GAP);
+      const x = START + col * (TILE_SIZE + TILE_GAP);
+      const y = START + row * (TILE_SIZE + TILE_GAP);
       const value = puzzle[i];
       
       if (value === 16) continue; // 빈 칸은 그리지 않음

--- a/src/SpaceInvadersCanvas.tsx
+++ b/src/SpaceInvadersCanvas.tsx
@@ -1,0 +1,240 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+// Use shared layout width so the game matches the rest of the catalog
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 0.75);
+const PLAYER_WIDTH = 60;
+const PLAYER_HEIGHT = 20;
+const PLAYER_SPEED = 300; // px per second
+const BULLET_SPEED = 500;
+const FIRE_DELAY = 300; // ms between shots
+const ALIEN_ROWS = 5;
+const ALIEN_COLS = 8;
+const ALIEN_WIDTH = 40;
+const ALIEN_HEIGHT = 30;
+const ALIEN_GAP = 10;
+const ALIEN_X_SPEED = 40;
+const ALIEN_DROP = 20;
+
+interface Bullet {
+  x: number;
+  y: number;
+}
+
+interface Alien {
+  x: number;
+  y: number;
+  alive: boolean;
+}
+
+const SpaceInvadersCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const lastTimeRef = useRef<number>(0);
+  const keysRef = useRef<Set<string>>(new Set());
+  const bulletsRef = useRef<Bullet[]>([]);
+  const aliensRef = useRef<Alien[]>([]);
+  const directionRef = useRef(1);
+  const playerXRef = useRef(CANVAS_WIDTH / 2 - PLAYER_WIDTH / 2);
+  const lastShotRef = useRef(0);
+
+  const [score, setScore] = useState(0);
+  const [gameState, setGameState] = useState<'playing' | 'won' | 'gameover'>('playing');
+
+  const initAliens = useCallback(() => {
+    const aliens: Alien[] = [];
+    const startX = (CANVAS_WIDTH - (ALIEN_COLS * (ALIEN_WIDTH + ALIEN_GAP) - ALIEN_GAP)) / 2;
+    for (let r = 0; r < ALIEN_ROWS; r++) {
+      for (let c = 0; c < ALIEN_COLS; c++) {
+        aliens.push({
+          x: startX + c * (ALIEN_WIDTH + ALIEN_GAP),
+          y: 60 + r * (ALIEN_HEIGHT + ALIEN_GAP),
+          alive: true
+        });
+      }
+    }
+    aliensRef.current = aliens;
+  }, []);
+
+  const startGame = useCallback(() => {
+    setScore(0);
+    setGameState('playing');
+    playerXRef.current = CANVAS_WIDTH / 2 - PLAYER_WIDTH / 2;
+    bulletsRef.current = [];
+    directionRef.current = 1;
+    lastShotRef.current = 0;
+    initAliens();
+  }, [initAliens]);
+
+  const update = useCallback((dt: number) => {
+    if (gameState !== 'playing') return;
+
+    // player movement
+    if (keysRef.current.has('ArrowLeft') || keysRef.current.has('KeyA')) {
+      playerXRef.current = Math.max(0, playerXRef.current - PLAYER_SPEED * dt);
+    }
+    if (keysRef.current.has('ArrowRight') || keysRef.current.has('KeyD')) {
+      playerXRef.current = Math.min(CANVAS_WIDTH - PLAYER_WIDTH, playerXRef.current + PLAYER_SPEED * dt);
+    }
+
+    // bullets
+    bulletsRef.current = bulletsRef.current.filter(b => {
+      b.y -= BULLET_SPEED * dt;
+      return b.y > -10;
+    });
+
+    // aliens
+    let hitEdge = false;
+    aliensRef.current.forEach(alien => {
+      if (!alien.alive) return;
+      alien.x += directionRef.current * ALIEN_X_SPEED * dt;
+      if (alien.x < 20 || alien.x + ALIEN_WIDTH > CANVAS_WIDTH - 20) {
+        hitEdge = true;
+      }
+    });
+    if (hitEdge) {
+      directionRef.current *= -1;
+      aliensRef.current.forEach(a => (a.y += ALIEN_DROP));
+    }
+
+    // collisions
+    bulletsRef.current.forEach(b => {
+      aliensRef.current.forEach(a => {
+        if (a.alive && b.x > a.x && b.x < a.x + ALIEN_WIDTH && b.y > a.y && b.y < a.y + ALIEN_HEIGHT) {
+          a.alive = false;
+          b.y = -20;
+          setScore(s => s + 10);
+        }
+      });
+    });
+
+    // win/lose check
+    const playerY = CANVAS_HEIGHT - PLAYER_HEIGHT - 10;
+    if (aliensRef.current.every(a => !a.alive)) {
+      setGameState('won');
+    } else if (aliensRef.current.some(a => a.alive && a.y + ALIEN_HEIGHT >= playerY)) {
+      setGameState('gameover');
+    }
+  }, [gameState]);
+
+  const draw = useCallback((ctx: CanvasRenderingContext2D) => {
+    ctx.fillStyle = '#000';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+
+    const playerY = CANVAS_HEIGHT - PLAYER_HEIGHT - 10;
+    ctx.fillStyle = '#00ff00';
+    ctx.fillRect(playerXRef.current, playerY, PLAYER_WIDTH, PLAYER_HEIGHT);
+
+    ctx.fillStyle = '#ffff00';
+    bulletsRef.current.forEach(b => {
+      ctx.fillRect(b.x - 2, b.y, 4, 10);
+    });
+
+    ctx.fillStyle = '#ff4444';
+    aliensRef.current.forEach(a => {
+      if (a.alive) ctx.fillRect(a.x, a.y, ALIEN_WIDTH, ALIEN_HEIGHT);
+    });
+
+    ctx.fillStyle = '#fff';
+    ctx.font = '20px Arial';
+    ctx.fillText(`Score: ${score}`, 20, 30);
+
+    if (gameState === 'gameover' || gameState === 'won') {
+      ctx.fillStyle = 'rgba(0,0,0,0.7)';
+      ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+      ctx.textAlign = 'center';
+      ctx.fillStyle = gameState === 'won' ? '#00ff00' : '#ff4444';
+      ctx.font = '48px Arial';
+      ctx.fillText(gameState === 'won' ? 'YOU WIN!' : 'GAME OVER', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2);
+      ctx.fillStyle = '#fff';
+      ctx.font = '24px Arial';
+      ctx.fillText('Press R to Restart', CANVAS_WIDTH / 2, CANVAS_HEIGHT / 2 + 40);
+      ctx.textAlign = 'left';
+    }
+  }, [score, gameState]);
+
+  const loop = useCallback((time: number) => {
+    if (!lastTimeRef.current) lastTimeRef.current = time;
+    const dt = (time - lastTimeRef.current) / 1000;
+    lastTimeRef.current = time;
+    update(dt);
+    const ctx = canvasRef.current?.getContext('2d');
+    if (ctx) draw(ctx);
+    animationRef.current = requestAnimationFrame(loop);
+  }, [update, draw]);
+
+  useEffect(() => {
+    startGame();
+  }, [startGame]);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (['ArrowLeft', 'ArrowRight', 'KeyA', 'KeyD', 'Space', 'KeyR'].includes(e.code)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      keysRef.current.add(e.code);
+      if (e.code === 'Space' && gameState === 'playing') {
+        const now = performance.now();
+        if (now - lastShotRef.current > FIRE_DELAY) {
+          bulletsRef.current.push({
+            x: playerXRef.current + PLAYER_WIDTH / 2,
+            y: CANVAS_HEIGHT - PLAYER_HEIGHT - 15,
+          });
+          lastShotRef.current = now;
+        }
+      }
+      if (e.code === 'KeyR' && gameState !== 'playing') {
+        startGame();
+      }
+    };
+    const handleKeyUp = (e: KeyboardEvent) => {
+      keysRef.current.delete(e.code);
+    };
+    window.addEventListener('keydown', handleKeyDown, { capture: true });
+    window.addEventListener('keyup', handleKeyUp, { capture: true });
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown, { capture: true });
+      window.removeEventListener('keyup', handleKeyUp, { capture: true });
+    };
+  }, [gameState, startGame]);
+
+  useEffect(() => {
+    animationRef.current = requestAnimationFrame(loop);
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+    };
+  }, [loop]);
+
+  const gameStats = <div>점수: {score}</div>;
+  const instructions = '←/→ 또는 A/D 이동, Space 발사, R 재시작';
+  const actionButtons = (
+    <GameButton onClick={startGame} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  return (
+    <GameManager
+      title="Space Invaders"
+      gameIcon="👾"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        gameTitle="Space Invaders"
+      />
+    </GameManager>
+  );
+};
+
+export default SpaceInvadersCanvas;
+

--- a/src/TowerBuilderCanvas.tsx
+++ b/src/TowerBuilderCanvas.tsx
@@ -1,0 +1,151 @@
+import React, { useEffect, useRef, useState } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+
+const TowerBuilderCanvas: React.FC<{ width?: number; height?: number }> = ({ width = 300, height = 500 }) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [score, setScore] = useState(0);
+  const [best, setBest] = useState<number>(() => Number(localStorage.getItem('towerHighScore')) || 0);
+  const scoreRef = useRef(0);
+  const bestRef = useRef(best);
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const blockHeight = 20;
+    const baseWidth = 100;
+    let blocks: { x: number; width: number }[] = [{ x: (width - baseWidth) / 2, width: baseWidth }];
+    let active = { x: 0, width: baseWidth };
+    let dir = 1;
+    let speed = 2;
+    let gameOver = false;
+    let animationId: number;
+
+    const drop = () => {
+      if (gameOver) return;
+      const prev = blocks[blocks.length - 1];
+      const overlapStart = Math.max(prev.x, active.x);
+      const overlapEnd = Math.min(prev.x + prev.width, active.x + active.width);
+      const overlap = overlapEnd - overlapStart;
+      if (overlap <= 0) {
+        gameOver = true;
+        setStatus('Game Over - Press R');
+        if (scoreRef.current > bestRef.current) {
+          bestRef.current = scoreRef.current;
+          setBest(bestRef.current);
+          localStorage.setItem('towerHighScore', String(bestRef.current));
+        }
+        return;
+      }
+      blocks.push({ x: overlapStart, width: overlap });
+      scoreRef.current += overlap * blockHeight;
+      setScore(scoreRef.current);
+      if (scoreRef.current > bestRef.current) {
+        bestRef.current = scoreRef.current;
+        setBest(bestRef.current);
+        localStorage.setItem('towerHighScore', String(bestRef.current));
+      }
+      active = { x: 0, width: overlap };
+      if (height - blockHeight * (blocks.length + 1) <= 0) {
+        gameOver = true;
+        setStatus('Game Over - Press R');
+      }
+    };
+
+    const reset = () => {
+      blocks = [{ x: (width - baseWidth) / 2, width: baseWidth }];
+      active = { x: 0, width: baseWidth };
+      dir = 1;
+      speed = 2;
+      scoreRef.current = 0;
+      setScore(0);
+      gameOver = false;
+      setStatus('');
+    };
+
+    const update = () => {
+      if (!gameOver) {
+        active.x += dir * speed;
+        if (active.x <= 0 || active.x + active.width >= width) {
+          dir *= -1;
+          active.x = Math.max(0, Math.min(active.x, width - active.width));
+        }
+      }
+    };
+
+    const draw = () => {
+      ctx.clearRect(0, 0, width, height);
+      ctx.fillStyle = '#222';
+      ctx.fillRect(0, 0, width, height);
+      blocks.forEach((b, i) => {
+        ctx.fillStyle = `hsl(${(i * 40) % 360},70%,60%)`;
+        const y = height - blockHeight * (i + 1);
+        ctx.fillRect(b.x, y, b.width, blockHeight);
+      });
+      if (!gameOver) {
+        ctx.fillStyle = '#fff';
+        const y = height - blockHeight * (blocks.length + 1);
+        ctx.fillRect(active.x, y, active.width, blockHeight);
+      }
+    };
+
+    const loop = () => {
+      update();
+      draw();
+      animationId = requestAnimationFrame(loop);
+    };
+    animationId = requestAnimationFrame(loop);
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === ' ' || e.key === 'Enter') {
+        e.preventDefault();
+        drop();
+      } else if (e.key === 'r') {
+        e.preventDefault();
+        reset();
+      }
+      e.stopPropagation();
+    };
+
+    window.addEventListener('keydown', handleKey);
+    canvas.addEventListener('click', drop);
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      window.removeEventListener('keydown', handleKey);
+      canvas.removeEventListener('click', drop);
+    };
+  }, [width, height]);
+
+  const gameStats = (
+    <div style={{ textAlign: 'center' }}>
+      <div>점수: {score} | 최고: {best}</div>
+      {status && <div style={{ marginTop: 4 }}>{status}</div>}
+    </div>
+  );
+
+  const instructions = 'Space/Enter/클릭: 블록 놓기\nR: 리셋';
+
+  return (
+    <GameManager
+      title="Tower Builder"
+      gameIcon="🏗️"
+      gameStats={gameStats}
+      instructions={instructions}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={width}
+        height={height}
+        gameTitle="Tower Builder"
+      />
+    </GameManager>
+  );
+};
+
+export default TowerBuilderCanvas;
+

--- a/src/WatermelonCanvas.tsx
+++ b/src/WatermelonCanvas.tsx
@@ -1,0 +1,301 @@
+import React, { useRef, useEffect, useState, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameCanvas from './components/GameCanvas';
+import GameButton from './components/GameButton';
+import { layout } from './theme/gameTheme';
+
+interface Fruit {
+  x: number;
+  y: number;
+  vy: number;
+  radius: number;
+  level: number;
+}
+
+const CANVAS_WIDTH = layout.maxWidth;
+const CANVAS_HEIGHT = Math.round(layout.maxWidth * 1.2);
+const PIT_WIDTH = Math.round(CANVAS_WIDTH * 0.65);
+const PIT_LEFT = (CANVAS_WIDTH - PIT_WIDTH) / 2;
+const PIT_RIGHT = PIT_LEFT + PIT_WIDTH;
+const GRAVITY = 900; // px/s^2
+const MOVE_SPEED = 200;
+const FRUIT_RADII = [16, 24, 32, 44, 62, 88];
+const COLORS = ['#ffb347', '#ffcc33', '#c1e1c5', '#ff9999', '#99ccff', '#ff7f7f'];
+const EMOJIS = ['🍎', '🍊', '🍋', '🍐', '🍑', '🍉'];
+
+const clampX = (x: number, radius: number) =>
+  Math.max(PIT_LEFT + radius, Math.min(PIT_RIGHT - radius, x));
+
+const createFruit = (x = CANVAS_WIDTH / 2) => {
+  const level = Math.random() < 0.5 ? 0 : 1;
+  const radius = FRUIT_RADII[level];
+  return {
+    x: clampX(x, radius),
+    y: 40,
+    vy: 0,
+    radius,
+    level,
+  };
+};
+
+const WatermelonCanvas: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number>();
+  const fruitsRef = useRef<Fruit[]>([]);
+  const currentRef = useRef<Fruit>(createFruit());
+  const keys = useRef({ left: false, right: false });
+  const lastDropRef = useRef(0);
+  const DROP_DELAY = 500; // ms
+
+  const [score, setScore] = useState(0);
+  const [gameOver, setGameOver] = useState(false);
+
+  const reset = useCallback(() => {
+    fruitsRef.current = [];
+    currentRef.current = createFruit();
+    setScore(0);
+    setGameOver(false);
+  }, []);
+
+  const dropCurrent = useCallback(() => {
+    if (gameOver) return;
+    const now = performance.now();
+    if (now - lastDropRef.current < DROP_DELAY) return;
+    lastDropRef.current = now;
+    fruitsRef.current.push({ ...currentRef.current });
+    const lastX = currentRef.current.x;
+    currentRef.current = createFruit(lastX);
+  }, [gameOver]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (['a', 'd', 'ArrowLeft', 'ArrowRight', ' ', 'r'].includes(e.key)) {
+        e.preventDefault();
+        e.stopPropagation();
+      }
+      switch (e.key) {
+        case 'a':
+        case 'ArrowLeft':
+          keys.current.left = true;
+          break;
+        case 'd':
+        case 'ArrowRight':
+          keys.current.right = true;
+          break;
+        case ' ': // drop
+          dropCurrent();
+          break;
+        case 'r':
+          reset();
+          break;
+      }
+    },
+    [dropCurrent, reset]
+  );
+
+  const handleKeyUp = useCallback((e: KeyboardEvent) => {
+    if (['a', 'd', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+      e.preventDefault();
+      e.stopPropagation();
+    }
+    switch (e.key) {
+      case 'a':
+      case 'ArrowLeft':
+        keys.current.left = false;
+        break;
+      case 'd':
+      case 'ArrowRight':
+        keys.current.right = false;
+        break;
+    }
+  }, []);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    canvas?.addEventListener('click', dropCurrent);
+    window.addEventListener('keydown', handleKeyDown);
+    window.addEventListener('keyup', handleKeyUp);
+    return () => {
+      canvas?.removeEventListener('click', dropCurrent);
+      window.removeEventListener('keydown', handleKeyDown);
+      window.removeEventListener('keyup', handleKeyUp);
+    };
+  }, [dropCurrent, handleKeyDown, handleKeyUp]);
+
+  const update = useCallback(
+    (dt: number) => {
+      const current = currentRef.current;
+      if (current) {
+        if (keys.current.left) current.x -= MOVE_SPEED * dt;
+        if (keys.current.right) current.x += MOVE_SPEED * dt;
+        current.x = clampX(current.x, current.radius);
+      }
+
+      const fruits = fruitsRef.current;
+      fruits.forEach((f) => {
+        f.vy += GRAVITY * dt;
+        f.y += f.vy * dt;
+        if (f.y + f.radius > CANVAS_HEIGHT) {
+          f.y = CANVAS_HEIGHT - f.radius;
+          f.vy = 0;
+        }
+        f.x = clampX(f.x, f.radius);
+      });
+
+      // merging before collision resolution
+      const remove = new Set<number>();
+      const additions: Fruit[] = [];
+      for (let i = 0; i < fruits.length; i++) {
+        for (let j = i + 1; j < fruits.length; j++) {
+          if (remove.has(i) || remove.has(j)) continue;
+          const a = fruits[i];
+          const b = fruits[j];
+          if (a.level === b.level) {
+            const dx = b.x - a.x;
+            const dy = b.y - a.y;
+            const dist = Math.hypot(dx, dy);
+            if (dist < a.radius + b.radius) {
+              const level = a.level + 1;
+              if (level < FRUIT_RADII.length) {
+                additions.push({
+                  x: (a.x + b.x) / 2,
+                  y: (a.y + b.y) / 2,
+                  vy: 0,
+                  radius: FRUIT_RADII[level],
+                  level,
+                });
+                remove.add(i);
+                remove.add(j);
+                setScore((s) => s + (level + 1) * 10);
+              }
+            }
+          }
+        }
+      }
+      if (remove.size > 0) {
+        fruitsRef.current = fruits
+          .filter((_, idx) => !remove.has(idx))
+          .concat(additions);
+      }
+
+      const updated = fruitsRef.current;
+      for (let i = 0; i < updated.length; i++) {
+        for (let j = i + 1; j < updated.length; j++) {
+          const a = updated[i];
+          const b = updated[j];
+          const dx = b.x - a.x;
+          const dy = b.y - a.y;
+          const dist = Math.hypot(dx, dy);
+          const minDist = a.radius + b.radius;
+          if (dist < minDist && dist > 0) {
+            const overlap = minDist - dist;
+            const nx = dx / dist;
+            const ny = dy / dist;
+            a.x -= nx * overlap / 2;
+            a.y -= ny * overlap / 2;
+            b.x += nx * overlap / 2;
+            b.y += ny * overlap / 2;
+            if (ny > 0) a.vy = 0;
+            if (ny < 0) b.vy = 0;
+          }
+        }
+      }
+
+      // game over check
+      for (const f of fruitsRef.current) {
+        if (f.y - f.radius <= 0) {
+          setGameOver(true);
+          break;
+        }
+      }
+    },
+    [setScore]
+  );
+
+  const draw = useCallback((ctx: CanvasRenderingContext2D) => {
+    ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+    ctx.fillStyle = '#222';
+    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+    // play area box
+    ctx.strokeStyle = '#555';
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+    ctx.moveTo(PIT_LEFT, 0);
+    ctx.lineTo(PIT_LEFT, CANVAS_HEIGHT);
+    ctx.lineTo(PIT_RIGHT, CANVAS_HEIGHT);
+    ctx.lineTo(PIT_RIGHT, 0);
+    ctx.stroke();
+
+    fruitsRef.current.forEach((f) => {
+      ctx.beginPath();
+      ctx.arc(f.x, f.y, f.radius, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS[f.level % COLORS.length];
+      ctx.fill();
+      ctx.font = `${f.radius * 1.6}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(EMOJIS[f.level % EMOJIS.length], f.x, f.y + 1);
+    });
+
+    const current = currentRef.current;
+    if (current) {
+      ctx.beginPath();
+      ctx.arc(current.x, current.y, current.radius, 0, Math.PI * 2);
+      ctx.fillStyle = COLORS[current.level % COLORS.length];
+      ctx.globalAlpha = 0.8;
+      ctx.fill();
+      ctx.globalAlpha = 1;
+      ctx.font = `${current.radius * 1.6}px serif`;
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(EMOJIS[current.level % EMOJIS.length], current.x, current.y + 1);
+    }
+  }, []);
+
+  useEffect(() => {
+    const ctx = canvasRef.current?.getContext('2d');
+    if (!ctx) return;
+    let last = performance.now();
+
+    const loop = (time: number) => {
+      const dt = (time - last) / 1000;
+      last = time;
+      if (!gameOver) update(dt);
+      draw(ctx);
+      animationRef.current = requestAnimationFrame(loop);
+    };
+    animationRef.current = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animationRef.current!);
+  }, [update, draw, gameOver]);
+
+  const gameStats = (
+    <div style={{ textAlign: 'center' }}>점수: {score}</div>
+  );
+  const instructions =
+    'A/D 또는 ←→로 이동, Space/클릭으로 과일을 떨어뜨리세요. 같은 과일을 합쳐 더 큰 수박을 만드세요. R로 재시작.';
+  const actionButtons = (
+    <GameButton onClick={reset} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  return (
+    <GameManager
+      title="Watermelon Game"
+      gameIcon="🍉"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      <GameCanvas
+        ref={canvasRef}
+        width={CANVAS_WIDTH}
+        height={CANVAS_HEIGHT}
+        gameTitle="Watermelon Game"
+      />
+    </GameManager>
+  );
+};
+
+export default WatermelonCanvas;
+

--- a/src/WhackAMoleCanvas.tsx
+++ b/src/WhackAMoleCanvas.tsx
@@ -1,0 +1,119 @@
+import React, { useState, useEffect, useCallback } from 'react';
+import GameManager from './components/GameManager';
+import GameButton from './components/GameButton';
+
+const GRID_SIZE = 3;
+const GAME_TIME = 30; // seconds
+const SPAWN_INTERVAL = 800; // ms
+
+const WhackAMoleCanvas: React.FC = () => {
+  const [score, setScore] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(GAME_TIME);
+  const [active, setActive] = useState<number | null>(null);
+  const [running, setRunning] = useState(true);
+
+  // 두더지 출현 타이머
+  useEffect(() => {
+    if (!running) return;
+    const moleTimer = setInterval(() => {
+      setActive(Math.floor(Math.random() * GRID_SIZE * GRID_SIZE));
+    }, SPAWN_INTERVAL);
+    return () => clearInterval(moleTimer);
+  }, [running]);
+
+  // 게임 시간 카운트다운
+  useEffect(() => {
+    if (!running) return;
+    if (timeLeft <= 0) {
+      setRunning(false);
+      setActive(null);
+      return;
+    }
+    const timer = setTimeout(() => setTimeLeft(t => t - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [timeLeft, running]);
+
+  const whack = useCallback((index: number) => {
+    if (!running) return;
+    if (index === active) {
+      setScore(s => s + 1);
+      setActive(null);
+    }
+  }, [active, running]);
+
+  const reset = () => {
+    setScore(0);
+    setTimeLeft(GAME_TIME);
+    setRunning(true);
+  };
+
+  const gridSize = 100;
+  const grid = (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: `repeat(${GRID_SIZE}, ${gridSize}px)`,
+        gap: 8,
+        justifyContent: 'center'
+      }}
+    >
+      {Array.from({ length: GRID_SIZE * GRID_SIZE }).map((_, i) => (
+        <div
+          key={i}
+          onClick={() => whack(i)}
+          style={{
+            width: gridSize,
+            height: gridSize,
+            background: '#444',
+            borderRadius: 8,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            cursor: 'pointer',
+            userSelect: 'none'
+          }}
+        >
+          {active === i && (
+            <div
+              style={{
+                width: gridSize * 0.6,
+                height: gridSize * 0.6,
+                borderRadius: '50%',
+                background: '#8B4513'
+              }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+
+  const gameStats = (
+    <div style={{ textAlign: 'center', color: '#bcbcbe' }}>
+      <div>점수: {score}</div>
+      <div>남은 시간: {timeLeft}s</div>
+    </div>
+  );
+
+  const actionButtons = (
+    <GameButton onClick={reset} variant="primary" size="large">
+      다시 시작
+    </GameButton>
+  );
+
+  const instructions = '두더지를 클릭해 점수를 올리세요! 30초 동안 최대한 많이 잡으세요.';
+
+  return (
+    <GameManager
+      title="Whack-a-Mole"
+      gameIcon="🐹"
+      gameStats={gameStats}
+      instructions={instructions}
+      actionButtons={actionButtons}
+    >
+      {grid}
+    </GameManager>
+  );
+};
+
+export default WhackAMoleCanvas;

--- a/src/components/GameManager.tsx
+++ b/src/components/GameManager.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { spacing, typography, colors } from '../theme/gameTheme';
+import { spacing, typography, colors, layout } from '../theme/gameTheme';
 
 interface GameManagerProps {
   // 게임 식별 정보
@@ -92,25 +92,29 @@ const GameManager: React.FC<GameManagerProps> = ({
       </button>
 
       {/* 메인 게임 영역 - 중앙 정렬 */}
-      <div style={{
-        width: '100%',
-        maxWidth: '1200px',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        gap: spacing.xl
-      }}>
+      <div
+        style={{
+          width: '100%',
+          maxWidth: layout.maxWidth,
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: spacing.xl,
+        }}
+      >
         
         {/* 상단 영역 - 파란색 박스 (게임 상태/점수) */}
-        <div style={{
-          background: colors.panelBackground,
-          borderRadius: 12,
-          padding: spacing.lg,
-          width: '100%',
-          maxWidth: '800px',
-          border: `2px solid ${colors.accent}`,
-          boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
-        }}>
+        <div
+          style={{
+            background: colors.panelBackground,
+            borderRadius: 12,
+            padding: spacing.lg,
+            width: '100%',
+            maxWidth: layout.maxWidth,
+            border: `2px solid ${colors.accent}`,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+          }}
+        >
           {/* 게임 타이틀 */}
           <div style={{
             textAlign: 'center',
@@ -149,29 +153,35 @@ const GameManager: React.FC<GameManagerProps> = ({
         </div>
 
         {/* 중앙 게임 캔버스 영역 - 빨간색 박스 */}
-        <div style={{
-          background: colors.canvasBackground,
-          borderRadius: 16,
-          padding: spacing.md,
-          border: `2px solid ${colors.canvasBorder}`,
-          boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center'
-        }}>
+        <div
+          style={{
+            background: colors.canvasBackground,
+            borderRadius: 16,
+            padding: spacing.md,
+            border: `2px solid ${colors.canvasBorder}`,
+            boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+            display: 'flex',
+            justifyContent: 'center',
+            alignItems: 'center',
+            width: '100%',
+            maxWidth: layout.maxWidth,
+          }}
+        >
           {children}
         </div>
 
         {/* 하단 영역 - 녹색 박스 (조작법/기능 버튼) */}
-        <div style={{
-          background: colors.panelBackground,
-          borderRadius: 12,
-          padding: spacing.lg,
-          width: '100%',
-          maxWidth: '800px',
-          border: `2px solid ${colors.success}`,
-          boxShadow: '0 4px 20px rgba(0,0,0,0.3)'
-        }}>
+        <div
+          style={{
+            background: colors.panelBackground,
+            borderRadius: 12,
+            padding: spacing.lg,
+            width: '100%',
+            maxWidth: layout.maxWidth,
+            border: `2px solid ${colors.success}`,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+          }}
+        >
           
           {/* 조작법 */}
           {instructions && (

--- a/src/components/GameMenu.tsx
+++ b/src/components/GameMenu.tsx
@@ -1,62 +1,61 @@
-import React from "react";
-
-export type GameId = "menu" | "pingpong" | "tetris" | "snake" | "omok" | "lightsout" | "simon" | "reaction" | "aim" | "breakout" | "flappy" | "memory" | "dodge" | "2048" | "slide" | "sokoban" | "connect4" | "minigolf" | "tictactoe";
+import React from 'react';
+import { GameDefinition, GameId } from '../games';
 
 type Props = {
-  onSelect: (id: Exclude<GameId, "menu">) => void;
+  games: readonly GameDefinition[];
+  onSelect: (id: GameId) => void;
 };
 
-export default function GameMenu({ onSelect }: Props) {
-  const Card: React.FC<{
-    title: string;
-    desc: string;
-    onClick: () => void;
-  }> = ({ title, desc, onClick }) => (
+export default function GameMenu({ games, onSelect }: Props) {
+  const Card: React.FC<{ title: string; desc: string; onClick: () => void }> = ({
+    title,
+    desc,
+    onClick,
+  }) => (
     <button
       onClick={onClick}
       style={{
-        display: "grid",
+        display: 'grid',
         gap: 8,
-        textAlign: "left",
-        background:
-          "linear-gradient(180deg, rgba(35,36,42,.9), rgba(27,28,33,.9))",
-        border: "1px solid rgba(255,255,255,.08)",
+        textAlign: 'left',
+        background: 'linear-gradient(180deg, rgba(35,36,42,.9), rgba(27,28,33,.9))',
+        border: '1px solid rgba(255,255,255,.08)',
         borderRadius: 14,
         padding: 16,
         width: 280,
-        cursor: "pointer",
+        cursor: 'pointer',
         boxShadow:
-          "0 10px 30px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.03)",
-        color: "#e8e8ea",
+          '0 10px 30px rgba(0,0,0,.35), inset 0 0 0 1px rgba(255,255,255,.03)',
+        color: '#e8e8ea',
       }}
     >
       <div style={{ fontWeight: 800, fontSize: 18 }}>{title}</div>
-      <div style={{ fontSize: 13, color: "#bcbcbe", lineHeight: 1.35 }}>
-        {desc}
-      </div>
+      <div style={{ fontSize: 13, color: '#bcbcbe', lineHeight: 1.35 }}>{desc}</div>
     </button>
   );
 
   return (
     <div
       style={{
-        minHeight: "100vh",
-        background: "#0f0f12",
-        color: "#e8e8ea",
-        display: "grid",
-        placeItems: "center",
+        minHeight: '100vh',
+        background: '#0f0f12',
+        color: '#e8e8ea',
         fontFamily:
           'ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Noto Sans KR", sans-serif',
         padding: 24,
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
       }}
     >
-      <div style={{ display: "grid", gap: 18, placeItems: "center" }}>
+      <div style={{ display: 'grid', gap: 18, placeItems: 'center', width: '100%', maxWidth: 880 }}>
         <div
           style={{
             fontWeight: 900,
             fontSize: 28,
-            letterSpacing: ".4px",
-            textAlign: "center",
+            letterSpacing: '.4px',
+            textAlign: 'center',
           }}
         >
           🎮 미니 게임 모음
@@ -64,114 +63,38 @@ export default function GameMenu({ onSelect }: Props) {
 
         <div
           style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(240px, 1fr))',
             gap: 16,
-            alignItems: "stretch",
-            width: "min(880px, 92vw)",
+            alignItems: 'stretch',
+            width: 'min(880px, 92vw)',
           }}
         >
-          <Card
-            title="🏓 Ping Pong"
-            desc="마우스/키보드로 패들을 조작해 AI와 대결해요."
-            onClick={() => onSelect("pingpong")}
-          />
-          <Card
-            title="🧱 Tetris"
-            desc="회전/드랍/홀드로 라인을 지우며 점수를 올려요."
-            onClick={() => onSelect("tetris")}
-          />
-          <Card
-            title="🐍 Snake"
-            desc="먹이를 먹고 길어지세요. 벽/몸에 부딪히면 게임 오버!"
-            onClick={() => onSelect("snake")}
-          />
-          <Card
-            title="○● Omok"
-            desc="번갈아 돌을 놓아 다섯 줄을 만들어요."
-            onClick={() => onSelect("omok")}
-          />
-          <Card
-            title="💡 Lights Out"
-            desc="모든 불을 끄세요! 셀을 누르면 상하좌우가 토글됩니다."
-            onClick={() => onSelect("lightsout")}
-          />
-          <Card
-            title="🎨 Simon Says"
-            desc="점점 길어지는 색상 패턴을 기억해서 따라하세요!"
-            onClick={() => onSelect("simon")}
-          />
-          <Card
-            title="⚡ Reaction Test"
-            desc="화면이 초록색으로 바뀌는 순간 클릭! 반응속도를 테스트하세요."
-            onClick={() => onSelect("reaction")}
-          />
-          <Card
-            title="🎯 Aim Trainer"
-            desc="나타나는 원 타격을 븠르게 클릭! 마우스 정확도를 향상시켜요."
-            onClick={() => onSelect("aim")}
-          />
-          <Card
-            title="🧱 Breakout"
-            desc="공과 패들로 벽돌을 부수세요! 물리 충돌과 반사를 느껴보세요."
-            onClick={() => onSelect("breakout")}
-          />
-          <Card
-            title="🐦 Flappy Bird"
-            desc="점프해서 파이프 사이를 통과하세요! 중력과 가속도를 마스터하세요."
-            onClick={() => onSelect("flappy")}
-          />
-          <Card
-            title="🧠 Memory Cards"
-            desc="같은 그림의 카드 2장을 찾아서 매칭하세요! 기억력과 집중력을 테스트해보세요."
-            onClick={() => onSelect("memory")}
-          />
-          <Card
-            title="🚫 Dodge Game"
-            desc="WASD로 이동해서 떨어지는 블록을 피하세요! 시간이 지날수록 난이도가 증가합니다."
-            onClick={() => onSelect("dodge")}
-          />
-          <Card
-            title="🔢 2048"
-            desc="같은 숫자 타일을 슬라이드해서 합치고 2048을 만드세요! 전략적 사고가 필요합니다."
-            onClick={() => onSelect("2048")}
-          />
-          <Card
-            title="🧩 Slide Puzzle"
-            desc="빈 칸과 인접한 타일을 슬라이드하여 1~15 순서로 정렬하세요! 클래식 15퍼즐입니다."
-            onClick={() => onSelect("slide")}
-          />
-          <Card
-            title="🚚 Sokoban"
-            desc="박스를 목표 지점으로 밀어서 모든 퍼즐을 해결하세요! 되돌리기 기능과 5개 레벨 제공."
-            onClick={() => onSelect("sokoban")}
-          />
-          <Card
-            title="🔴 Connect Four"
-            desc="6x7 격자에서 4개 칩을 연속으로 연결하세요! AI와 대전하며 전략적 사고력을 기르세요."
-            onClick={() => onSelect("connect4")}
-          />
-          <Card
-            title="⛳ Mini Golf"
-            desc="드래그로 파워를 조절해서 골프공을 홀에 넣으세요! 물리 엔진과 벽 반사를 활용하세요."
-            onClick={() => onSelect("minigolf")}
-          />
-          <Card
-            title="⭕ Tic-Tac-Toe"
-            desc="X와 O를 번갈아 두며, 가로·세로·대각선으로 3개를 먼저 연결하면 승리! 클래식 틱택토 게임입니다."
-            onClick={() => onSelect("tictactoe")}
-          />
+          {games.map((g) => (
+            <Card
+              key={g.id}
+              title={g.title}
+              desc={g.description}
+              onClick={() => onSelect(g.id)}
+            />
+          ))}
         </div>
 
         <div
           style={{
             marginTop: 8,
             fontSize: 12,
-            color: "#a9a9ad",
-            textAlign: "center",
+            color: '#a9a9ad',
+            textAlign: 'center',
           }}
         >
-          Tip: 키보드 <b>1</b> = Ping Pong, <b>2</b> = Tetris, <b>3</b> = Snake, <b>4</b> = Omok, <b>5</b> = Lights Out, <b>6</b> = Simon Says, <b>7</b> = Reaction Test, <b>8</b> = Aim Trainer, <b>9</b> = Breakout, <b>0</b> = Flappy Bird, <b>T</b> = Tic-Tac-Toe
+          Tip:{' '}
+          {games.map((g, i) => (
+            <span key={g.id}>
+              <b>{g.hotkey.toUpperCase()}</b> = {g.tipName}
+              {i < games.length - 1 ? ', ' : ''}
+            </span>
+          ))}
         </div>
       </div>
     </div>

--- a/src/games.tsx
+++ b/src/games.tsx
@@ -1,0 +1,331 @@
+import React from 'react';
+import PingPongCanvas from './PingPongCanvas';
+import TetrisCanvas from './TetrisCanvas';
+import SnakeCanvas from './SnakeCanvas';
+import OmokCanvas from './OmokCanvas';
+import LightsOutCanvas from './LightsOutCanvas';
+import SimonSaysCanvas from './SimonSaysCanvas';
+import ReactionTestCanvas from './ReactionTestCanvas';
+import AimTrainerCanvas from './AimTrainerCanvas';
+import BreakoutCanvas from './BreakoutCanvas';
+import FlappyBirdCanvas from './FlappyBirdCanvas';
+import MemoryGameCanvas from './MemoryGameCanvas';
+import DodgeGameCanvas from './DodgeGameCanvas';
+import Game2048Canvas from './Game2048Canvas';
+import SlidePuzzleCanvas from './SlidePuzzleCanvas';
+import SokobanCanvas from './SokobanCanvas';
+import ConnectFourCanvas from './ConnectFourCanvas';
+import MiniGolfCanvas from './MiniGolfCanvas';
+import FroggerCanvas from './FroggerCanvas';
+import TicTacToeCanvas from './TicTacToeCanvas';
+import WhackAMoleCanvas from './WhackAMoleCanvas';
+import SpaceInvadersCanvas from './SpaceInvadersCanvas';
+import GalagaCanvas from './GalagaCanvas';
+import MastermindCanvas from './MastermindCanvas';
+import MinesweeperCanvas from './MinesweeperCanvas';
+import PicrossCanvas from './PicrossCanvas';
+import MatchThreeCanvas from './MatchThreeCanvas';
+import HextrisCanvas from './HextrisCanvas';
+import PuyoPuyoCanvas from './PuyoPuyoCanvas';
+import PenguinJumpCanvas from './PenguinJumpCanvas';
+import PumpItUpCanvas from './PumpItUpCanvas';
+import ColumnsCanvas from './ColumnsCanvas';
+import PaperIoCanvas from './PaperIoCanvas';
+import TowerBuilderCanvas from './TowerBuilderCanvas';
+import WatermelonCanvas from './WatermelonCanvas';
+import BubbleShooterCanvas from './BubbleShooterCanvas';
+import DominoCanvas from './DominoCanvas';
+
+export const games = [
+  {
+    id: 'pingpong',
+    title: '🏓 Ping Pong',
+    tipName: 'Ping Pong',
+    description: '마우스/키보드로 패들을 조작해 AI와 대결해요.',
+    hotkey: '1',
+    render: () => <PingPongCanvas width={900} height={540} />,
+  },
+  {
+    id: 'tetris',
+    title: '🧱 Tetris',
+    tipName: 'Tetris',
+    description: '회전/드랍/홀드로 라인을 지우며 점수를 올려요.',
+    hotkey: '2',
+    render: () => <TetrisCanvas />,
+  },
+  {
+    id: 'snake',
+    title: '🐍 Snake',
+    tipName: 'Snake',
+    description: '먹이를 먹고 길어지세요. 벽/몸에 부딪히면 게임 오버!',
+    hotkey: '3',
+    render: () => <SnakeCanvas />,
+  },
+  {
+    id: 'omok',
+    title: '○● Omok',
+    tipName: 'Omok',
+    description: '번갈아 돌을 놓아 다섯 줄을 만들어요.',
+    hotkey: '4',
+    render: () => <OmokCanvas />,
+  },
+  {
+    id: 'lightsout',
+    title: '💡 Lights Out',
+    tipName: 'Lights Out',
+    description: '모든 불을 끄세요! 셀을 누르면 상하좌우가 토글됩니다.',
+    hotkey: '5',
+    render: () => <LightsOutCanvas />,
+  },
+  {
+    id: 'simon',
+    title: '🎨 Simon Says',
+    tipName: 'Simon Says',
+    description: '점점 길어지는 색상 패턴을 기억해서 따라하세요!',
+    hotkey: '6',
+    render: () => <SimonSaysCanvas />,
+  },
+  {
+    id: 'reaction',
+    title: '⚡ Reaction Test',
+    tipName: 'Reaction Test',
+    description: '화면이 초록색으로 바뀌는 순간 클릭! 반응속도를 테스트하세요.',
+    hotkey: '7',
+    render: () => <ReactionTestCanvas />,
+  },
+  {
+    id: 'aim',
+    title: '🎯 Aim Trainer',
+    tipName: 'Aim Trainer',
+    description: '나타나는 원 타격을 빠르게 클릭! 마우스 정확도를 향상시켜요.',
+    hotkey: '8',
+    render: () => <AimTrainerCanvas />,
+  },
+  {
+    id: 'breakout',
+    title: '🧱 Breakout',
+    tipName: 'Breakout',
+    description: '공과 패들로 벽돌을 부수세요! 물리 충돌과 반사를 느껴보세요.',
+    hotkey: '9',
+    render: () => <BreakoutCanvas />,
+  },
+  {
+    id: 'flappy',
+    title: '🐦 Flappy Bird',
+    tipName: 'Flappy Bird',
+    description: '점프해서 파이프 사이를 통과하세요! 중력과 가속도를 마스터하세요.',
+    hotkey: '0',
+    render: () => <FlappyBirdCanvas />,
+  },
+  {
+    id: 'memory',
+    title: '🧠 Memory Cards',
+    tipName: 'Memory Cards',
+    description: '같은 그림의 카드 2장을 찾아서 매칭하세요! 기억력과 집중력을 테스트해보세요.',
+    hotkey: 'm',
+    render: () => <MemoryGameCanvas />,
+  },
+  {
+    id: 'dodge',
+    title: '🚫 Dodge Game',
+    tipName: 'Dodge Game',
+    description: 'WASD로 이동해서 떨어지는 블록을 피하세요! 시간이 지날수록 난이도가 증가합니다.',
+    hotkey: 'd',
+    render: () => <DodgeGameCanvas />,
+  },
+  {
+    id: '2048',
+    title: '🔢 2048',
+    tipName: '2048',
+    description: '같은 숫자 타일을 슬라이드해서 합치고 2048을 만드세요! 전략적 사고가 필요합니다.',
+    hotkey: '-',
+    render: () => <Game2048Canvas />,
+  },
+  {
+    id: 'slide',
+    title: '🧩 Slide Puzzle',
+    tipName: 'Slide Puzzle',
+    description: '빈 칸과 인접한 타일을 슬라이드하여 1~15 순서로 정렬하세요! 클래식 15퍼즐입니다.',
+    hotkey: '=',
+    render: () => <SlidePuzzleCanvas />,
+  },
+  {
+    id: 'sokoban',
+    title: '🚚 Sokoban',
+    tipName: 'Sokoban',
+    description: '박스를 목표 지점으로 밀어서 모든 퍼즐을 해결하세요! 되돌리기 기능과 5개 레벨 제공.',
+    hotkey: 's',
+    render: () => <SokobanCanvas />,
+  },
+  {
+    id: 'connect4',
+    title: '🔴 Connect Four',
+    tipName: 'Connect Four',
+    description: '6x7 격자에서 4개 칩을 연속으로 연결하세요! AI와 대전하며 전략적 사고력을 기르세요.',
+    hotkey: 'c',
+    render: () => <ConnectFourCanvas />,
+  },
+  {
+    id: 'minigolf',
+    title: '⛳ Mini Golf',
+    tipName: 'Mini Golf',
+    description: '드래그로 파워를 조절해서 골프공을 홀에 넣으세요! 물리 엔진과 벽 반사를 활용하세요.',
+    hotkey: 'g',
+    render: () => <MiniGolfCanvas />,
+  },
+  {
+    id: 'mastermind',
+    title: '🧠 Mastermind',
+    tipName: 'Mastermind',
+    description: '색 조합을 추리해 10번 안에 정답을 맞혀보세요!',
+    hotkey: 'h',
+    render: () => <MastermindCanvas />,
+  },
+  {
+    id: 'minesweeper',
+    title: '💣 Minesweeper',
+    tipName: 'Minesweeper',
+    description: '지뢰를 피해 모든 칸을 여세요. 우클릭으로 깃발을 표시합니다.',
+    hotkey: 'b',
+    render: () => <MinesweeperCanvas />,
+  },
+  {
+    id: 'picross',
+    title: '🖼️ Picross',
+    tipName: 'Picross',
+    description: '숫자 힌트를 이용해 그림을 완성하세요. 좌클릭=채우기, 우클릭=X 표시.',
+    hotkey: 'p',
+    render: () => <PicrossCanvas />,
+  },
+  {
+    id: 'match3',
+    title: '💎 Match-3',
+    tipName: 'Match-3',
+    description: '인접한 보석을 교환해 3개 이상 매치하면 제거되고 점수를 얻어요.',
+    hotkey: 'j',
+    render: () => <MatchThreeCanvas />,
+  },
+  {
+    id: 'frogger',
+    title: '🐸 Frogger',
+    tipName: 'Frogger',
+    description: '자동차를 피해 개구리를 위쪽 안전지대로 이동시키세요! 방향키로 조작합니다.',
+    hotkey: 'f',
+    render: () => <FroggerCanvas />,
+  },
+  {
+    id: 'tictactoe',
+    title: '⭕ Tic-Tac-Toe',
+    tipName: 'Tic-Tac-Toe',
+    description: 'X와 O를 번갈아 두며, 가로·세로·대각선으로 3개를 먼저 연결하면 승리! 클래식 틱택토 게임입니다.',
+    hotkey: 't',
+    render: () => <TicTacToeCanvas />,
+  },
+  {
+    id: 'whack',
+    title: '🐹 Whack-a-Mole',
+    tipName: 'Whack-a-Mole',
+    description: '두더지가 튀어나올 때 클릭해서 점수를 올려요! 30초 동안 최대한 많이 잡으세요.',
+    hotkey: 'w',
+    render: () => <WhackAMoleCanvas />,
+  },
+  {
+    id: 'galaga',
+    title: '🚀 Galaga',
+    tipName: 'Galaga',
+    description: '적 우주선을 쏘아 격추하세요. A/D 또는 ←→ 이동, Space 발사.',
+    hotkey: 'a',
+    render: () => <GalagaCanvas />,
+  },
+  {
+    id: 'space',
+    title: '👾 Space Invaders',
+    tipName: 'Space Invaders',
+    description: '우주선을 움직여 외계인 침략자들을 물리치세요! Spacebar로 발사하세요.',
+    hotkey: 'i',
+    render: () => <SpaceInvadersCanvas />,
+  },
+  {
+    id: 'hextris',
+    title: '🔷 Hextris',
+    tipName: 'Hextris',
+    description: '육각형을 회전시켜 떨어지는 블록의 색을 맞추세요.',
+    hotkey: 'x',
+    render: () => <HextrisCanvas />,
+  },
+  {
+    id: 'puyo',
+    title: '🍡 Puyo Puyo',
+    tipName: 'Puyo Puyo',
+    description: '떨어지는 2개 블록을 맞춰 4개 이상 연결해 제거하세요.',
+    hotkey: 'y',
+    render: () => <PuyoPuyoCanvas />,
+  },
+  {
+    id: 'penguin',
+    title: '🐧 Penguin Jump',
+    tipName: 'Penguin Jump',
+    description: '펭귄을 조작해 플랫폼을 뛰어넘고 깃발에 도달하세요.',
+    hotkey: 'k',
+    render: () => <PenguinJumpCanvas />,
+  },
+  {
+    id: 'pumpitup',
+    title: '🎵 Pump It Up',
+    tipName: 'Pump It Up',
+    description: 'QWER 키로 노트를 타이밍에 맞춰 입력하는 리듬 게임.',
+    hotkey: 'u',
+    render: () => <PumpItUpCanvas />,
+  },
+  {
+    id: 'columns',
+    title: '🔶 Columns',
+    tipName: 'Columns',
+    description: '세 가지 색 블록을 떨어뜨려 3개 이상 맞추면 제거되는 퍼즐.',
+    hotkey: 'l',
+    render: () => <ColumnsCanvas />,
+  },
+  {
+    id: 'tower',
+    title: '🏗️ Tower Builder',
+    tipName: 'Tower Builder',
+    description: '좌우로 움직이는 블록을 쌓아 면적 기반 점수를 겨루세요. Space/클릭: 놓기, R: 리셋',
+    hotkey: 'v',
+    render: () => <TowerBuilderCanvas />,
+  },
+  {
+    id: 'paper',
+    title: '📄 Paper.io',
+    tipName: 'Paper.io',
+    description: '영역 밖을 나갔다 돌아오면 경로 내 영역을 차지하는 스네이크 변형.',
+    hotkey: 'o',
+    render: () => <PaperIoCanvas />,
+  },
+  {
+    id: 'watermelon',
+    title: '🍉 Watermelon Game',
+    tipName: 'Watermelon Game',
+    description: '같은 과일을 합쳐 더 큰 수박을 만드는 물리 퍼즐.',
+    hotkey: 'q',
+    render: () => <WatermelonCanvas />,
+  },
+  {
+    id: 'domino',
+    title: '🁬 Domino Topple',
+    tipName: 'Domino Topple',
+    description: '도미노를 차례로 쓰러뜨리세요. 클릭/스페이스: 시작, R: 리셋',
+    hotkey: 'n',
+    render: () => <DominoCanvas />,
+  },
+  {
+    id: 'bubbleshooter',
+    title: '🔵 Bubble Shooter',
+    tipName: 'Bubble Shooter',
+    description: '같은 색 버블 3개를 맞춰 제거하고 모든 버블을 없애보세요.',
+    hotkey: 'e',
+    render: () => <BubbleShooterCanvas />,
+  },
+] as const;
+
+export type GameDefinition = typeof games[number];
+export type GameId = GameDefinition['id'];

--- a/src/theme/gameTheme.ts
+++ b/src/theme/gameTheme.ts
@@ -68,6 +68,11 @@ export const spacing = {
   xxl: 24
 };
 
+// 공통 레이아웃 설정
+export const layout = {
+  maxWidth: 640
+};
+
 export const gameContainerStyle: React.CSSProperties = {
   display: "grid",
   gap: spacing.lg,
@@ -84,7 +89,10 @@ export const canvasStyle: React.CSSProperties = {
   background: colors.canvasBackground,
   boxShadow: "0 10px 40px rgba(0,0,0,0.5), inset 0 0 0 1px rgba(255,255,255,0.06)",
   borderRadius: 14,
-  touchAction: "none"
+  touchAction: "none",
+  width: "100%",
+  height: "auto",
+  display: "block"
 };
 
 export const buttonStyles = {


### PR DESCRIPTION
## Summary
- keep menu hotkeys from blocking gameplay and allow Escape to return to menu
- decorate Watermelon fruits with emoji icons, remember last drop position, and restrict play to a centered pit
- add Galaga shooter mini-game and register it under hotkey `a`
- fix Bubble Shooter grid collisions and clear unsupported clusters
- update browser tab title with current game name

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6f5b11c8320a713106ebe51a06a